### PR TITLE
Potential fix for code scanning alert no. 4: Incomplete multi-character sanitization

### DIFF
--- a/package.json
+++ b/package.json
@@ -48,7 +48,8 @@
     "react-hook-form": "^7.72.1",
     "react-router-dom": "^7.14.0",
     "redis": "^5.12.1",
-    "zod": "^4.3.6"
+    "zod": "^4.3.6",
+    "html-to-text": "^9.0.5"
   },
   "devDependencies": {
     "@playwright/test": "^1.59.1",

--- a/src/server/services/GmailService.ts
+++ b/src/server/services/GmailService.ts
@@ -1,4 +1,5 @@
 import { google, gmail_v1 } from 'googleapis';
+import { convert } from 'html-to-text';
 import { generateOfferEmailSubject, generateOfferEmailBody } from '../lib/emailTemplate';
 
 export interface SendEmailParams {
@@ -93,12 +94,11 @@ export class GmailService {
   }
 
   private htmlToPlainText(html: string): string {
-    return html
-      .replace(/&nbsp;/g, ' ')
-      .replace(/&lt;/g, '<')
-      .replace(/&gt;/g, '>')
-      .replace(/&quot;/g, '"')
-      .replace(/<[^>]*>/g, '') // Remove HTML tags after decoding entities
-      .trim();
+    return convert(html, {
+      wordwrap: false,
+      selectors: [
+        { selector: 'a', options: { ignoreHref: true } },
+      ],
+    }).trim();
   }
 }


### PR DESCRIPTION
Potential fix for [https://github.com/dachrisch/league.finance/security/code-scanning/4](https://github.com/dachrisch/league.finance/security/code-scanning/4)

Use a robust HTML-to-text conversion library instead of ad-hoc regex stripping.  
Best fix here: replace `htmlToPlainText` implementation with `html-to-text`’s `convert`, which parses HTML structurally and avoids incomplete multi-character sanitization issues.

In `src/server/services/GmailService.ts`:
1. Add an import for `convert` from `html-to-text`.
2. Replace the current chained `.replace(...)` logic in `htmlToPlainText` with a call to `convert(html, ...)`, returning trimmed plain text.
3. Keep existing behavior/function signature unchanged.

This avoids fragile regex sanitization and preserves functionality (generate readable plain text from HTML).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
