### PR TITLE
refactor: fix mongoose deprecation warning

### DIFF
--- a/docs/superpowers/plans/2026-04-06-leagues-finance-standalone.md
+++ b/docs/superpowers/plans/2026-04-06-leagues-finance-standalone.md
@@ -790,7 +790,7 @@ passport.use(
           displayName: profile.displayName,
           $setOnInsert: { role },
         },
-        { upsert: true, new: true, setDefaultsOnInsert: true }
+        { upsert: true, returnDocument: 'after', setDefaultsOnInsert: true }
       );
 
       done(null, user);
@@ -1240,7 +1240,7 @@ export const configsRouter = router({
   update: adminProcedure
     .input(z.object({ id: z.string(), data: UpdateFinancialConfigSchema }))
     .mutation(async ({ input }) => {
-      const config = await FinancialConfig.findByIdAndUpdate(input.id, input.data, { new: true }).lean();
+      const config = await FinancialConfig.findByIdAndUpdate(input.id, input.data, { returnDocument: 'after' }).lean();
       if (!config) throw new TRPCError({ code: 'NOT_FOUND' });
       return config;
     }),

--- a/docs/superpowers/plans/2026-04-08-offer-reporting.md
+++ b/docs/superpowers/plans/2026-04-08-offer-reporting.md
@@ -1244,7 +1244,7 @@ export const associationsRouter = router({
       })
     )
     .mutation(async ({ input }) => {
-      const association = await Association.findByIdAndUpdate(input.id, input.data, { new: true });
+      const association = await Association.findByIdAndUpdate(input.id, input.data, { returnDocument: 'after' });
       if (!association) {
         throw new TRPCError({ code: 'NOT_FOUND' });
       }
@@ -1417,7 +1417,7 @@ export const offersRouter = router({
       const offer = await Offer.findByIdAndUpdate(
         input.id,
         { status: input.status },
-        { new: true }
+        { returnDocument: 'after' }
       );
       if (!offer) {
         throw new TRPCError({ code: 'NOT_FOUND' });
@@ -1643,7 +1643,7 @@ customizePrice: protectedProcedure
     const lineItem = await OfferLineItem.findOneAndUpdate(
       { offerId: input.offerId, leagueId: input.leagueId },
       { customPrice: input.customPrice },
-      { new: true }
+      { returnDocument: 'after' }
     );
 
     if (!lineItem) {

--- a/src/server/routers/finance/associations.ts
+++ b/src/server/routers/finance/associations.ts
@@ -67,7 +67,7 @@ export const associationsRouter = router({
       })
     )
     .mutation(async ({ input }) => {
-      const association = await Association.findByIdAndUpdate(input.id, input.data, { new: true });
+      const association = await Association.findByIdAndUpdate(input.id, input.data, { returnDocument: 'after' });
       if (!association) {
         throw new TRPCError({ code: 'NOT_FOUND' });
       }

--- a/src/server/routers/finance/contacts.ts
+++ b/src/server/routers/finance/contacts.ts
@@ -34,7 +34,7 @@ export const contactsRouter = router({
     .input(z.object({ id: z.string(), data: UpdateContactSchema }))
     .mutation(async ({ input }) => {
       const contact = await Contact.findByIdAndUpdate(input.id, input.data, {
-        new: true,
+        returnDocument: 'after',
       }).lean();
       if (!contact) throw new TRPCError({ code: 'NOT_FOUND' });
       return normalizeContact(contact);

--- a/src/server/routers/test-data.ts
+++ b/src/server/routers/test-data.ts
@@ -92,7 +92,7 @@ export const testDataRouter = router({
         const created = await Association.findOneAndUpdate(
           { name: assoc.name },
           assoc,
-          { upsert: true, new: true }
+          { upsert: true, returnDocument: 'after' }
         );
         testAssocId = created._id.toString();
         results.push({ type: 'association', name: assoc.name, status: 'created' });
@@ -117,7 +117,7 @@ export const testDataRouter = router({
           await Contact.findOneAndUpdate(
             { name: contact.name, associationId: contact.associationId },
             contact,
-            { upsert: true, new: true }
+            { upsert: true, returnDocument: 'after' }
           );
           results.push({ type: 'contact', name: contact.name, status: 'created' });
         } catch (err: any) {


### PR DESCRIPTION
Replaces deprecated 'new' option with 'returnDocument: after' in findOneAndUpdate and findByIdAndUpdate calls.