### PR TITLE
feat: unified offer edit experience

### DIFF
--- a/docs/plans/2026-05-27-unified-offer-edit-design.md
+++ b/docs/plans/2026-05-27-unified-offer-edit-design.md
@@ -1,0 +1,26 @@
+# Design Spec: Unified Offer Edit Page
+
+## Overview
+The current "Edit Offer" experience is a 2-step wizard designed for creation, which leads to incomplete pre-filling and a repetitive UX. This redesign moves the "Edit" flow to a single-screen, unified component.
+
+## Architecture
+- **Page:** `src/client/pages/OfferNewPage.tsx` will be updated (or a new `OfferEditPage.tsx` created) to handle both flows.
+- **Components:** Reuse `Step1` and `Step2` logic but render them vertically without step-based navigation.
+- **State:** Enhanced `useOfferCreation` hook to handle initialization from existing data correctly.
+
+## Data Flow
+1. **Fetch:** Load offer by ID.
+2. **Sync:** Map `offer.configs` and metadata to wizard state.
+3. **Unified View:** Render Metadata (Association/Contact/Season) at the top, Pricing in the middle, and League Selection at the bottom.
+4. **Save:** Use the existing `update` mutation which handles bulk configuration resets for draft offers.
+
+## Technical Tasks
+- Fix `resetWithData` in `useOfferCreation.ts`.
+- Create a "Unified" mode in `Step1` and `Step2` components.
+- Integrate both sections into a single scrollable view for editing.
+- Ensure "Season Change" logic correctly handles league selection resets.
+
+## Verification Plan
+- **Pre-fill Check:** Open an existing draft and verify all fields (Association, Contact, Season, Pricing, selected Leagues) are correct.
+- **Global Pricing Check:** Change the global price and save; verify all league configurations are updated in the detail page.
+- **League Selection Check:** Add/remove leagues and verify the `FinancialConfig` records are updated accordingly.

--- a/docs/plans/2026-05-27-unified-offer-edit-implementation.md
+++ b/docs/plans/2026-05-27-unified-offer-edit-implementation.md
@@ -1,0 +1,193 @@
+# Unified Offer Edit Implementation Plan
+
+> **For Claude:** REQUIRED SUB-SKILL: Use superpowers:executing-plans to implement this plan task-by-task.
+
+**Goal:** Create a unified, single-screen edit experience for offers that combines metadata, pricing, and league selection.
+
+**Architecture:** Refactor existing wizard components to support a "unified" layout and fix pre-filling logic in the state hook.
+
+**Tech Stack:** React, TypeScript, TRPC, Vitest.
+
+---
+
+### Task 1: Fix Pre-filling in `useOfferCreation` hook
+
+**Files:**
+- Modify: `src/client/hooks/useOfferCreation.ts`
+- Test: `src/client/hooks/__tests__/useOfferCreation.test.ts`
+
+**Step 1: Write failing test for `resetWithData` with backend format**
+```typescript
+// Add to useOfferCreation.test.ts
+it('should correctly map backend configs to selectedLeagueIds', () => {
+  const { result } = renderHook(() => useOfferCreation());
+  const mockOfferResponse = {
+    offer: {
+      associationId: 'assoc-1',
+      contactId: 'cont-1',
+      seasonId: 1,
+      leagueIds: [10, 11]
+    },
+    configs: [
+      { leagueId: 10, costModel: 'SEASON', baseRateOverride: 50, expectedTeamsCount: 5 },
+      { leagueId: 11, costModel: 'SEASON', baseRateOverride: 50, expectedTeamsCount: 5 }
+    ]
+  };
+  
+  act(() => {
+    result.current.resetWithData(mockOfferResponse);
+  });
+  
+  expect(result.current.step2.selectedLeagueIds).toEqual(['10', '11']);
+  expect(result.current.step2.pricing.baseRateOverride).toBe(50);
+});
+```
+
+**Step 2: Run test to verify it fails**
+Run: `npm test src/client/hooks/__tests__/useOfferCreation.test.ts`
+Expected: FAIL (leagueIds empty or pricing not pre-filled)
+
+**Step 3: Update `resetWithData` implementation**
+```typescript
+const resetWithData = useCallback((data: any) => {
+  const { offer, configs } = data;
+  const firstConfig = configs?.[0];
+  
+  setState({
+    currentStep: 'step1',
+    step1: {
+      pathChoice: 'existing',
+      selectedAssociationId: offer.associationId,
+      selectedContactId: offer.contactId,
+      selectedSeasonId: String(offer.seasonId),
+      pasteInput: '',
+      isExtracting: false,
+    },
+    step2: {
+      pricing: {
+        costModel: firstConfig?.costModel === 'GAMEDAY' ? 'perGameDay' : 'flatFee',
+        baseRateOverride: firstConfig?.baseRateOverride || undefined,
+        expectedTeamsCount: firstConfig?.expectedTeamsCount || 0,
+      },
+      selectedLeagueIds: offer.leagueIds.map(String),
+      leagueSearchTerm: '',
+      leagueFilterType: 'All',
+    },
+  });
+}, []);
+```
+
+**Step 4: Run test to verify it passes**
+Run: `npm test src/client/hooks/__tests__/useOfferCreation.test.ts`
+
+**Step 5: Commit**
+```bash
+git add src/client/hooks/useOfferCreation.ts src/client/hooks/__tests__/useOfferCreation.test.ts
+git commit -m "fix: pre-fill logic in useOfferCreation hook"
+```
+
+---
+
+### Task 2: Add Unified Mode to `Step1`
+
+**Files:**
+- Modify: `src/client/components/Offer/Step1/Step1.tsx`
+
+**Step 1: Add `isUnified` prop and conditionally hide "Path Selection"**
+```tsx
+// src/client/components/Offer/Step1/Step1.tsx
+interface Step1Props {
+  // ... existing
+  isUnified?: boolean;
+}
+
+// In component:
+{!isUnified && (
+  <PathSelectionSection ... />
+)}
+```
+
+**Step 2: Hide "Next" button in unified mode**
+```tsx
+{!isUnified && (
+  <button onClick={onNext}>Next</button>
+)}
+```
+
+**Step 3: Commit**
+```bash
+git add src/client/components/Offer/Step1/Step1.tsx
+git commit -m "feat: add isUnified mode to Step1"
+```
+
+---
+
+### Task 3: Add Unified Mode to `Step2`
+
+**Files:**
+- Modify: `src/client/components/Offer/Step2/Step2.tsx`
+
+**Step 1: Add `isUnified` prop and conditionally hide Progress Header**
+```tsx
+// src/client/components/Offer/Step2/Step2.tsx
+{!isUnified && (
+  <div className={styles.wizardHeader}>...</div>
+)}
+```
+
+**Step 2: Hide "Back" and "Cancel" buttons in footer when unified**
+The footer should only show "Save Changes" (handled by the parent container).
+
+**Step 3: Commit**
+```bash
+git add src/client/components/Offer/Step2/Step2.tsx
+git commit -m "feat: add isUnified mode to Step2"
+```
+
+---
+
+### Task 4: Create Unified `OfferEditWizard` Component
+
+**Files:**
+- Create: `src/client/components/Offer/OfferEditWizard.tsx`
+
+**Step 1: Implement the unified view**
+```tsx
+export function OfferEditWizard({ editId }: { editId: string }) {
+  // Similar logic to OfferCreateWizard but renders Step1 and Step2 vertically
+  // Pass isUnified={true} to both
+  return (
+    <div className="unified-edit-container">
+       <h1>Edit Offer</h1>
+       <Step1 ... isUnified />
+       <hr />
+       <Step2 ... isUnified />
+       <div className="footer-actions">
+          <button onClick={handleSave}>Save Changes</button>
+       </div>
+    </div>
+  );
+}
+```
+
+**Step 2: Update `OfferNewPage.tsx` to use the new component when `id` is present**
+
+**Step 3: Commit**
+```bash
+git add src/client/components/Offer/OfferEditWizard.tsx src/client/pages/OfferNewPage.tsx
+git commit -m "feat: implement unified OfferEditWizard"
+```
+
+---
+
+### Task 5: Final Verification
+
+**Step 1: Run E2E tests**
+Run: `npx playwright test e2e/test-frontend-create-offer.spec.ts`
+
+**Step 2: Manual Check**
+- Navigate to an existing offer.
+- Click "Edit".
+- Verify all data is pre-filled on one screen.
+- Change a price and save.
+- Verify the change persisted in the detail view.

--- a/src/client/components/Offer/OfferEditWizard.tsx
+++ b/src/client/components/Offer/OfferEditWizard.tsx
@@ -1,0 +1,189 @@
+// src/client/components/Offer/OfferEditWizard.tsx
+
+import { useMemo, useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { Step1 } from './Step1/Step1';
+import { Step2 } from './Step2/Step2';
+import { useOfferCreation } from '../../hooks/useOfferCreation';
+import { trpc } from '../../lib/trpc';
+import styles from '../../styles/OfferWizard.module.css';
+
+interface Season {
+  _id: string | number;
+  name: string;
+  slug: string;
+}
+
+interface Props {
+  editId: string;
+}
+
+export function OfferEditWizard({ editId }: Props) {
+  const navigate = useNavigate();
+  const wizard = useOfferCreation();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [hasInitialized, setHasInitialized] = useState(false);
+  const [submitError, setSubmitError] = useState<string | null>(null);
+
+  // Queries
+  const { data: associations = [] } = trpc.finance.associations.list.useQuery();
+  const { data: contacts = [] } = trpc.finance.contacts.list.useQuery();
+  const { data: seasons = [] } = trpc.finance.seasons.list.useQuery() as { data?: Season[] };
+  
+  const { data: existingOfferData, isLoading: isLoadingOffer } = trpc.finance.offers.get.useQuery(
+    { id: editId },
+    { enabled: !!editId }
+  );
+
+  // Initialize with existing data
+  useEffect(() => {
+    if (hasInitialized) return;
+
+    if (editId && existingOfferData) {
+      // Use existingOfferData.offer if it follows the new format, or just existingOfferData
+      wizard.resetWithData(existingOfferData);
+      setHasInitialized(true);
+    }
+  }, [editId, existingOfferData, hasInitialized, wizard]);
+
+  // Get leagues for selected season
+  const { data: leagues = [] } = trpc.finance.leagues.listBySeason.useQuery(
+    { seasonId: wizard.step1.selectedSeasonId || '' },
+    { enabled: !!wizard.step1.selectedSeasonId }
+  );
+
+  // Mutation
+  const updateMutation = trpc.finance.offers.update.useMutation();
+
+  // Handlers
+  const handleSaveOffer = async () => {
+    setIsSubmitting(true);
+    setSubmitError(null);
+    try {
+      const associationId = wizard.step1.selectedAssociationId;
+      const contactId = wizard.step1.selectedContactId;
+
+      if (!associationId || !contactId || !wizard.step1.selectedSeasonId) {
+        throw new Error('Missing required information: association, contact, or season');
+      }
+
+      const payload = {
+        associationId,
+        contactId,
+        seasonId: parseInt(wizard.step1.selectedSeasonId),
+        ...wizard.step2.pricing,
+        leagueIds: wizard.step2.selectedLeagueIds.map(id => parseInt(id)),
+      };
+
+      await updateMutation.mutateAsync({ id: editId, data: payload as any });
+      navigate(`/offers/${editId}`);
+    } catch (err: any) {
+      let errorMessage = 'Failed to save offer. Please check your information and try again.';
+
+      if (err?.message && !err.message.includes('TRPCClientError')) {
+        errorMessage = err.message;
+      } else if (err?.data?.message) {
+        errorMessage = err.data.message;
+      } else if (err?.shape?.message) {
+        errorMessage = err.shape.message;
+      }
+
+      setSubmitError(errorMessage);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  // Summary mapping
+  const summary = useMemo(() => {
+    const assoc = associations.find(a => a._id === wizard.step1.selectedAssociationId);
+    const contact = contacts.find(c => c._id === wizard.step1.selectedContactId);
+    const season = seasons.find(s => s._id.toString() === wizard.step1.selectedSeasonId?.toString());
+
+    return {
+      associationName: assoc?.name || '',
+      contactName: contact?.name || '',
+      seasonYear: season?.name || '',
+    };
+  }, [wizard.step1, associations, contacts, seasons]);
+
+  if (isLoadingOffer) {
+    return <div className={styles.wizard} style={{ padding: '40px', textAlign: 'center' }}>Loading offer data...</div>;
+  }
+
+  const canSave = wizard.step1.selectedAssociationId && 
+                  wizard.step1.selectedContactId && 
+                  wizard.step1.selectedSeasonId &&
+                  wizard.step2.selectedLeagueIds.length > 0 && 
+                  wizard.step2.pricing.expectedTeamsCount >= 0;
+
+  return (
+    <div className={styles.wizard} style={{ maxWidth: '800px' }}>
+      <div className={styles.wizardHeader}>
+        <h1 className={styles.wizardTitle}>Edit Offer</h1>
+      </div>
+
+      <div style={{ padding: '0 0 20px 0' }}>
+        <Step1
+          {...wizard.step1}
+          submitError={submitError}
+          associations={associations}
+          contacts={contacts}
+          seasons={seasons.map(s => ({ ...s, _id: s._id.toString() }))}
+          onUpdatePasteInput={wizard.updatePasteInput}
+          onSelectPath={wizard.selectPath}
+          onExtract={() => {}} // Not used in edit mode
+          onSelectAssociation={wizard.selectAssociation}
+          onSelectContact={wizard.selectContact}
+          onSelectSeason={wizard.selectSeason}
+          onUpdateExtractedData={wizard.updateExtractedData}
+          onNext={() => {}} // Not used in unified view
+          onCancel={() => {}} // Not used in unified view
+          isEdit={true}
+          isUnified={true}
+        />
+
+        <div style={{ borderTop: '1px solid var(--border-color)', marginTop: '20px' }}>
+          <Step2
+            summary={summary}
+            pricing={wizard.step2.pricing}
+            leagues={leagues}
+            selectedLeagueIds={wizard.step2.selectedLeagueIds}
+            leagueSearchTerm={wizard.step2.leagueSearchTerm}
+            leagueFilterType={wizard.step2.leagueFilterType || 'All'}
+            submitError={submitError}
+            onBack={() => {}} // Not used in unified view
+            onCancel={() => {}} // Not used in unified view
+            onCreate={handleSaveOffer}
+            onPricingChange={wizard.updatePricing}
+            onToggleLeague={wizard.toggleLeague}
+            onSearchChange={wizard.updateLeagueSearch}
+            onFilterChange={wizard.updateLeagueFilter}
+            onSelectAll={() => wizard.setSelectedLeagues(leagues.map(l => l._id.toString()))}
+            onClearAll={() => wizard.setSelectedLeagues([])}
+            onEditStep1={() => {}} // Already on the same page
+            isSubmitting={isSubmitting}
+            isEdit={true}
+            isUnified={true}
+          />
+        </div>
+      </div>
+
+      <div className={styles.wizardFooter}>
+        <div className={styles.footerHint}>Editing Offer {editId}</div>
+        <div className={styles.footerActions}>
+          <button className={`${styles.button} ${styles.buttonGhost}`} onClick={() => navigate(`/offers/${editId}`)}>
+            Cancel
+          </button>
+          <button
+            className={`${styles.button} ${styles.buttonPrimary}`}
+            onClick={handleSaveOffer}
+            disabled={!canSave || isSubmitting}
+          >
+            {isSubmitting ? 'Saving...' : 'Save Changes'}
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/client/components/Offer/Step1/Step1.tsx
+++ b/src/client/components/Offer/Step1/Step1.tsx
@@ -46,6 +46,7 @@ interface Step1Props {
   onNext: () => void;
   onCancel: () => void;
   isEdit?: boolean;
+  isUnified?: boolean;
 }
 
 export function Step1({
@@ -71,6 +72,7 @@ export function Step1({
   onNext,
   onCancel,
   isEdit = false,
+  isUnified = false,
 }: Step1Props) {
   // Check if user has filled in all required fields for either path
   const hasValidExtractedData = extractedData && selectedSeasonId && isValidExtraction(extractedData);
@@ -87,23 +89,25 @@ export function Step1({
   }));
 
   return (
-    <div className={styles.wizard}>
-      <div className={styles.wizardHeader}>
-        <h1 className={styles.wizardTitle}>{isEdit ? 'Edit Offer' : 'Create New Offer'}</h1>
-        <div className={styles.progressIndicator} role="progressbar" aria-valuenow={1} aria-valuemin={1} aria-valuemax={2}>
-          <div className={styles.progressStep}>
-            <div className={`${styles.progressDot} ${styles.active}`} aria-current="step" aria-label="Step 1: Association, Contact & Season">1</div>
-            <span className={styles.progressLabel}>Association, Contact & Season</span>
-          </div>
-          <span className={styles.progressSeparator} aria-hidden="true">›</span>
-          <div className={styles.progressStep}>
-            <div className={styles.progressDot} aria-label="Step 2: Pricing & Leagues">2</div>
-            <span className={styles.progressLabel}>Pricing & Leagues</span>
+    <div className={isUnified ? undefined : styles.wizard}>
+      {!isUnified && (
+        <div className={styles.wizardHeader}>
+          <h1 className={styles.wizardTitle}>{isEdit ? 'Edit Offer' : 'Create New Offer'}</h1>
+          <div className={styles.progressIndicator} role="progressbar" aria-valuenow={1} aria-valuemin={1} aria-valuemax={2}>
+            <div className={styles.progressStep}>
+              <div className={`${styles.progressDot} ${styles.active}`} aria-current="step" aria-label="Step 1: Association, Contact & Season">1</div>
+              <span className={styles.progressLabel}>Association, Contact & Season</span>
+            </div>
+            <span className={styles.progressSeparator} aria-hidden="true">›</span>
+            <div className={styles.progressStep}>
+              <div className={styles.progressDot} aria-label="Step 2: Pricing & Leagues">2</div>
+              <span className={styles.progressLabel}>Pricing & Leagues</span>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
-      <div style={{ padding: '0 20px' }}>
+      <div style={isUnified ? undefined : { padding: '0 20px' }}>
         {submitError && (
           <div style={{
             padding: '12px 16px',
@@ -133,23 +137,27 @@ export function Step1({
           onPostalCodeChange={(postalCode) => onUpdateExtractedData({ postalCode })}
         />
 
-        <div className={styles.divider}>or use existing records</div>
+        {!isUnified && (
+          <>
+            <div className={styles.divider}>or use existing records</div>
 
-        <UseExistingBlock
-          associations={associations}
-          contacts={contacts}
-          seasons={existingSeasons}
-          selectedAssociationId={selectedAssociationId}
-          selectedContactId={selectedContactId}
-          selectedSeasonId={selectedSeasonId}
-          onAssociationChange={onSelectAssociation}
-          onContactChange={onSelectContact}
-          onSeasonChange={onSelectSeason}
-          isActive={pathChoice === 'existing'}
-          onToggle={() => onSelectPath(pathChoice === 'existing' ? 'paste' : 'existing')}
-        />
+            <UseExistingBlock
+              associations={associations}
+              contacts={contacts}
+              seasons={existingSeasons}
+              selectedAssociationId={selectedAssociationId}
+              selectedContactId={selectedContactId}
+              selectedSeasonId={selectedSeasonId}
+              onAssociationChange={onSelectAssociation}
+              onContactChange={onSelectContact}
+              onSeasonChange={onSelectSeason}
+              isActive={pathChoice === 'existing'}
+              onToggle={() => onSelectPath(pathChoice === 'existing' ? 'paste' : 'existing')}
+            />
+          </>
+        )}
 
-        {pathChoice === 'paste' && (
+        {(pathChoice === 'paste' || isUnified) && (
           <SeasonBlock
             seasons={seasons}
             selectedSeasonId={selectedSeasonId}
@@ -159,21 +167,23 @@ export function Step1({
         )}
       </div>
 
-      <div className={styles.wizardFooter}>
-        <span className={styles.footerHint}>Step 1 of 2</span>
-        <div className={styles.footerActions}>
-          <button className={`${styles.button} ${styles.buttonGhost}`} onClick={onCancel}>
-            Cancel
-          </button>
-          <button
-            className={`${styles.button} ${styles.buttonPrimary}`}
-            onClick={onNext}
-            disabled={!canProceed}
-          >
-            Next: Pricing & Leagues →
-          </button>
+      {!isUnified && (
+        <div className={styles.wizardFooter}>
+          <span className={styles.footerHint}>Step 1 of 2</span>
+          <div className={styles.footerActions}>
+            <button className={`${styles.button} ${styles.buttonGhost}`} onClick={onCancel}>
+              Cancel
+            </button>
+            <button
+              className={`${styles.button} ${styles.buttonPrimary}`}
+              onClick={onNext}
+              disabled={!canProceed}
+            >
+              Next: Pricing & Leagues →
+            </button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/client/components/Offer/Step1/Step1.tsx
+++ b/src/client/components/Offer/Step1/Step1.tsx
@@ -121,25 +121,28 @@ export function Step1({
             ✕ {submitError}
           </div>
         )}
-        <PasteExtractBlock
-          pasteInput={pasteInput}
-          isExtracting={isExtracting}
-          extractionError={extractionError}
-          extractedData={extractedData}
-          onInputChange={onUpdatePasteInput}
-          onExtract={(text) => {
-            onSelectPath('paste');
-            onExtract(text);
-          }}
-          onEmailChange={(email) => onUpdateExtractedData({ email })}
-          onPhoneChange={(phone) => onUpdateExtractedData({ phone })}
-          onCityChange={(city) => onUpdateExtractedData({ city })}
-          onPostalCodeChange={(postalCode) => onUpdateExtractedData({ postalCode })}
-        />
+        
+        {(!isUnified || !isEdit) && (
+          <PasteExtractBlock
+            pasteInput={pasteInput}
+            isExtracting={isExtracting}
+            extractionError={extractionError}
+            extractedData={extractedData}
+            onInputChange={onUpdatePasteInput}
+            onExtract={(text) => {
+              onSelectPath('paste');
+              onExtract(text);
+            }}
+            onEmailChange={(email) => onUpdateExtractedData({ email })}
+            onPhoneChange={(phone) => onUpdateExtractedData({ phone })}
+            onCityChange={(city) => onUpdateExtractedData({ city })}
+            onPostalCodeChange={(postalCode) => onUpdateExtractedData({ postalCode })}
+          />
+        )}
 
-        {!isUnified && (
+        {(!isUnified || isEdit) && (
           <>
-            <div className={styles.divider}>or use existing records</div>
+            {(!isUnified && !isEdit) && <div className={styles.divider}>or use existing records</div>}
 
             <UseExistingBlock
               associations={associations}
@@ -151,13 +154,13 @@ export function Step1({
               onAssociationChange={onSelectAssociation}
               onContactChange={onSelectContact}
               onSeasonChange={onSelectSeason}
-              isActive={pathChoice === 'existing'}
-              onToggle={() => onSelectPath(pathChoice === 'existing' ? 'paste' : 'existing')}
+              isActive={isUnified || pathChoice === 'existing'}
+              onToggle={() => !isUnified && onSelectPath(pathChoice === 'existing' ? 'paste' : 'existing')}
             />
           </>
         )}
 
-        {(pathChoice === 'paste' || isUnified) && (
+        {(pathChoice === 'paste' || (isUnified && !isEdit)) && (
           <SeasonBlock
             seasons={seasons}
             selectedSeasonId={selectedSeasonId}

--- a/src/client/components/Offer/Step1/__tests__/Step1.test.tsx
+++ b/src/client/components/Offer/Step1/__tests__/Step1.test.tsx
@@ -23,6 +23,7 @@ describe('Step1', () => {
     onSelectAssociation: vi.fn(),
     onSelectContact: vi.fn(),
     onSelectSeason: vi.fn(),
+    onUpdateExtractedData: vi.fn(),
     onNext: vi.fn(),
     onCancel: vi.fn(),
   };
@@ -98,5 +99,28 @@ describe('Step1', () => {
     // 2. Paste subtitle (maybe)
     // 3. SeasonBlock Title
     expect(seasonBlocks.length).toBeGreaterThan(1);
+  });
+
+  it('should render unified mode correctly', () => {
+    const unifiedProps = {
+      ...mockProps,
+      isUnified: true,
+    };
+    render(<Step1 {...unifiedProps} />);
+
+    // Header should be hidden
+    expect(screen.queryByText(/Association, Contact & Season/i)).not.toBeInTheDocument();
+
+    // Divider/Path selection should be hidden
+    expect(screen.queryByText(/or use existing records/i)).not.toBeInTheDocument();
+
+    // Next button should be hidden
+    expect(screen.queryByRole('button', { name: /Next/i })).not.toBeInTheDocument();
+
+    // Paste extract block should still be there
+    expect(screen.getByText(/Paste & extract/i)).toBeInTheDocument();
+
+    // Season block should still be there
+    expect(screen.getByText(/Required to complete the offer/i)).toBeInTheDocument();
   });
 });

--- a/src/client/components/Offer/Step2/Step2.tsx
+++ b/src/client/components/Offer/Step2/Step2.tsx
@@ -90,12 +90,14 @@ export function Step2({
             ✕ {submitError}
           </div>
         )}
-        <SummarySection
-          associationName={summary.associationName}
-          contactName={summary.contactName}
-          seasonYear={summary.seasonYear}
-          onEdit={onEditStep1}
-        />
+        {!isUnified && (
+          <SummarySection
+            associationName={summary.associationName}
+            contactName={summary.contactName}
+            seasonYear={summary.seasonYear}
+            onEdit={onEditStep1}
+          />
+        )}
 
         <PricingSection
           costModel={pricing.costModel}

--- a/src/client/components/Offer/Step2/Step2.tsx
+++ b/src/client/components/Offer/Step2/Step2.tsx
@@ -30,6 +30,7 @@ interface Step2Props {
   onEditStep1: () => void;
   isSubmitting: boolean;
   isEdit?: boolean;
+  isUnified?: boolean;
 }
 
 export function Step2({
@@ -52,25 +53,28 @@ export function Step2({
   onEditStep1,
   isSubmitting,
   isEdit = false,
+  isUnified = false,
 }: Step2Props) {
   const canCreate = selectedLeagueIds.length > 0 && pricing.expectedTeamsCount >= 0;
 
   return (
     <div className={styles.wizard} style={{ maxWidth: '650px' }}>
-      <div className={styles.wizardHeader}>
-        <h1 className={styles.wizardTitle}>{isEdit ? 'Edit Offer' : 'Create New Offer'}</h1>
-        <div className={styles.progressIndicator} role="progressbar" aria-valuenow={2} aria-valuemin={1} aria-valuemax={2}>
-          <div className={styles.progressStep}>
-            <div className={`${styles.progressDot} ${styles.active}`} style={{ background: '#ecfdf5', color: '#10b981', borderColor: '#10b981' }} aria-label="Step 1 complete">✓</div>
-            <span className={styles.progressLabel}>Association, Contact & Season</span>
-          </div>
-          <span className={styles.progressSeparator} aria-hidden="true">›</span>
-          <div className={styles.progressStep}>
-            <div className={`${styles.progressDot} ${styles.active}`} aria-current="step" aria-label="Step 2: Pricing & Leagues">2</div>
-            <span className={styles.progressLabel}>Pricing & Leagues</span>
+      {!isUnified && (
+        <div className={styles.wizardHeader}>
+          <h1 className={styles.wizardTitle}>{isEdit ? 'Edit Offer' : 'Create New Offer'}</h1>
+          <div className={styles.progressIndicator} role="progressbar" aria-valuenow={2} aria-valuemin={1} aria-valuemax={2}>
+            <div className={styles.progressStep}>
+              <div className={`${styles.progressDot} ${styles.active}`} style={{ background: '#ecfdf5', color: '#10b981', borderColor: '#10b981' }} aria-label="Step 1 complete">✓</div>
+              <span className={styles.progressLabel}>Association, Contact & Season</span>
+            </div>
+            <span className={styles.progressSeparator} aria-hidden="true">›</span>
+            <div className={styles.progressStep}>
+              <div className={`${styles.progressDot} ${styles.active}`} aria-current="step" aria-label="Step 2: Pricing & Leagues">2</div>
+              <span className={styles.progressLabel}>Pricing & Leagues</span>
+            </div>
           </div>
         </div>
-      </div>
+      )}
 
       <div style={{ padding: '20px', overflowY: 'auto', maxHeight: 'calc(90vh - 120px)' }}>
         {submitError && (
@@ -113,23 +117,25 @@ export function Step2({
         />
       </div>
 
-      <div className={styles.wizardFooter}>
-        <button className={`${styles.button} ${styles.buttonGhost}`} onClick={onBack}>
-          ← Back to Step 1
-        </button>
-        <div className={styles.footerActions}>
-          <button className={`${styles.button} ${styles.buttonGhost}`} onClick={onCancel}>
-            Cancel
+      {!isUnified && (
+        <div className={styles.wizardFooter}>
+          <button className={`${styles.button} ${styles.buttonGhost}`} onClick={onBack}>
+            ← Back to Step 1
           </button>
-          <button
-            className={`${styles.button} ${styles.buttonPrimary}`}
-            onClick={onCreate}
-            disabled={!canCreate || isSubmitting}
-          >
-            {isSubmitting ? (isEdit ? 'Saving...' : 'Creating...') : (isEdit ? 'Save Changes' : 'Create Offer & Finish')}
-          </button>
+          <div className={styles.footerActions}>
+            <button className={`${styles.button} ${styles.buttonGhost}`} onClick={onCancel}>
+              Cancel
+            </button>
+            <button
+              className={`${styles.button} ${styles.buttonPrimary}`}
+              onClick={onCreate}
+              disabled={!canCreate || isSubmitting}
+            >
+              {isSubmitting ? (isEdit ? 'Saving...' : 'Creating...') : (isEdit ? 'Save Changes' : 'Create Offer & Finish')}
+            </button>
+          </div>
         </div>
-      </div>
+      )}
     </div>
   );
 }

--- a/src/client/components/Offer/Step2/__tests__/Step2.test.tsx
+++ b/src/client/components/Offer/Step2/__tests__/Step2.test.tsx
@@ -45,4 +45,21 @@ describe('Step2', () => {
     expect(screen.getByText(/Pricing Configuration/i)).toBeInTheDocument();
     expect(screen.getByText(/League Selection/i)).toBeInTheDocument();
   });
+
+  it('should not render header and footer when isUnified is true', () => {
+    render(<Step2 {...mockProps} isUnified={true} />);
+
+    // Header elements should not be present
+    expect(screen.queryByText(/Create New Offer/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Pricing & Leagues/i)).not.toBeInTheDocument();
+
+    // Footer elements should not be present
+    expect(screen.queryByText(/Back to Step 1/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Create Offer & Finish/i)).not.toBeInTheDocument();
+
+    // Content should still be present
+    expect(screen.getByText(/Review Details/i)).toBeInTheDocument();
+    expect(screen.getByText(/Pricing Configuration/i)).toBeInTheDocument();
+    expect(screen.getByText(/League Selection/i)).toBeInTheDocument();
+  });
 });

--- a/src/client/components/Offer/Step2/__tests__/Step2.test.tsx
+++ b/src/client/components/Offer/Step2/__tests__/Step2.test.tsx
@@ -57,8 +57,8 @@ describe('Step2', () => {
     expect(screen.queryByText(/Back to Step 1/i)).not.toBeInTheDocument();
     expect(screen.queryByText(/Create Offer & Finish/i)).not.toBeInTheDocument();
 
-    // Content should still be present
-    expect(screen.getByText(/Review Details/i)).toBeInTheDocument();
+    // Content should still be present (except Summary which is hidden in unified)
+    expect(screen.queryByText(/Review Details/i)).not.toBeInTheDocument();
     expect(screen.getByText(/Pricing Configuration/i)).toBeInTheDocument();
     expect(screen.getByText(/League Selection/i)).toBeInTheDocument();
   });

--- a/src/client/components/Offer/types.ts
+++ b/src/client/components/Offer/types.ts
@@ -43,6 +43,7 @@ export interface Step2State {
   selectedLeagueIds: string[];
   leagueSearchTerm: string;
   leagueFilterType?: 'All' | 'Youth' | 'Regional' | 'Division' | 'Other';
+  leaguePrices: Record<string, number | null>;
 }
 
 export interface WizardState {

--- a/src/client/hooks/__tests__/useOfferCreation.test.ts
+++ b/src/client/hooks/__tests__/useOfferCreation.test.ts
@@ -110,4 +110,27 @@ describe('useOfferCreation', () => {
     expect(result.current.step2.pricing.baseRateOverride).toBe(100);
     expect(result.current.step2.selectedLeagueIds).toEqual(['1', '2']);
   });
+
+  it('should correctly map backend configs to selectedLeagueIds', () => {
+    const { result } = renderHook(() => useOfferCreation());
+    const mockOfferResponse = {
+      offer: {
+        associationId: 'assoc-1',
+        contactId: 'cont-1',
+        seasonId: 1,
+        leagueIds: [10, 11]
+      },
+      configs: [
+        { leagueId: 10, costModel: 'SEASON', baseRateOverride: 50, expectedTeamsCount: 5 },
+        { leagueId: 11, costModel: 'SEASON', baseRateOverride: 50, expectedTeamsCount: 5 }
+      ]
+    };
+    
+    act(() => {
+      result.current.resetWithData(mockOfferResponse);
+    });
+    
+    expect(result.current.step2.selectedLeagueIds).toEqual(['10', '11']);
+    expect(result.current.step2.pricing.baseRateOverride).toBe(50);
+  });
 });

--- a/src/client/hooks/useOfferCreation.ts
+++ b/src/client/hooks/useOfferCreation.ts
@@ -198,9 +198,11 @@ export function useOfferCreation() {
     setState(initialState);
   }, []);
 
-  const resetWithData = useCallback((offer: any) => {
-    // Map existing offer to wizard state
-    const firstConfig = offer.financialConfigs?.[0];
+  const resetWithData = useCallback((data: any) => {
+    // Handle both new format { offer, configs } and legacy format
+    const offer = data.offer || data;
+    const configs = data.configs || data.financialConfigs;
+    const firstConfig = configs?.[0];
     
     setState({
       currentStep: 'step1',
@@ -218,7 +220,7 @@ export function useOfferCreation() {
           baseRateOverride: firstConfig?.baseRateOverride || undefined,
           expectedTeamsCount: firstConfig?.expectedTeamsCount || 0,
         },
-        selectedLeagueIds: offer.leagueIds.map(String),
+        selectedLeagueIds: (offer.leagueIds || []).map(String),
         leagueSearchTerm: '',
         leagueFilterType: 'All',
       },

--- a/src/client/hooks/useOfferCreation.ts
+++ b/src/client/hooks/useOfferCreation.ts
@@ -31,6 +31,7 @@ const initialState: WizardState = {
     selectedLeagueIds: [],
     leagueSearchTerm: '',
     leagueFilterType: 'All',
+    leaguePrices: {},
   },
 };
 
@@ -223,6 +224,10 @@ export function useOfferCreation() {
         selectedLeagueIds: (offer.leagueIds || []).map(String),
         leagueSearchTerm: '',
         leagueFilterType: 'All',
+        leaguePrices: configs?.reduce((acc: any, c: any) => {
+          acc[String(c.leagueId)] = c.customPrice;
+          return acc;
+        }, {}) || {},
       },
     });
   }, []);

--- a/src/client/pages/OfferNewPage.tsx
+++ b/src/client/pages/OfferNewPage.tsx
@@ -2,6 +2,7 @@
 
 import { useParams } from 'react-router-dom';
 import { OfferCreateWizard } from '../components/Offer/OfferCreateWizard';
+import { OfferEditWizard } from '../components/Offer/OfferEditWizard';
 
 export default function OfferNewPage() {
   const { id } = useParams<{ id: string }>();
@@ -9,7 +10,7 @@ export default function OfferNewPage() {
   return (
     <div style={{ padding: '20px', background: '#f9fafb', display: 'flex', flexDirection: 'column', alignItems: 'center' }}>
       <div style={{ width: '100%', maxWidth: '800px' }}>
-        <OfferCreateWizard editId={id} />
+        {id ? <OfferEditWizard editId={id} /> : <OfferCreateWizard />}
       </div>
     </div>
   );


### PR DESCRIPTION
This PR replaces the 2-step wizard with a unified, single-screen edit experience for offers. 

Key changes:
- Refactored `useOfferCreation` hook to correctly pre-fill data from backend.
- Added `isUnified` mode to `Step1` and `Step2` components.
- Created `OfferEditWizard` for a single-page editing experience.
- Updated `OfferNewPage` to switch between create/edit views automatically.
- Fixed type issues with `leaguePrices` in `WizardState`.