### PR TITLE
fix: resolve contact and league preselection in unified offer edit

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1151,9 +1151,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1171,9 +1168,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1191,9 +1185,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1211,9 +1202,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1231,9 +1219,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1251,9 +1236,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -3973,9 +3955,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -3997,9 +3976,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4021,9 +3997,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4045,9 +4018,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [

--- a/src/client/components/Offer/Step2/CategoryGroup.tsx
+++ b/src/client/components/Offer/Step2/CategoryGroup.tsx
@@ -39,24 +39,29 @@ export function CategoryGroup({
 
       <div className={`${styles.leagueCategoryContent} ${isOpen ? styles.open : ''}`}>
         <div className={styles.leagueCategoryList}>
-          {leagues.map((league) => (
-            <div
-              key={league._id}
-              className={styles.leagueItem}
-              onClick={() => onToggle(league._id)}
-            >
-              <input
-                type="checkbox"
-                className={styles.leagueCheckbox}
-                checked={selectedIds.includes(league._id)}
-                onChange={() => {}} // Controlled by parent
-              />
-              <span className={styles.leagueName}>{league.name}</span>
-              {selectedIds.includes(league._id) && (
-                <span className={styles.leagueCheckmark}>✓</span>
-              )}
-            </div>
-          ))}
+          {leagues.map((league) => {
+            const leagueId = String(league._id);
+            const isSelected = selectedIds.includes(leagueId);
+            
+            return (
+              <div
+                key={leagueId}
+                className={styles.leagueItem}
+                onClick={() => onToggle(leagueId)}
+              >
+                <input
+                  type="checkbox"
+                  className={styles.leagueCheckbox}
+                  checked={isSelected}
+                  onChange={() => {}} // Controlled by parent
+                />
+                <span className={styles.leagueName}>{league.name}</span>
+                {isSelected && (
+                  <span className={styles.leagueCheckmark}>✓</span>
+                )}
+              </div>
+            );
+          })}
         </div>
       </div>
     </div>

--- a/src/client/hooks/useOfferCreation.ts
+++ b/src/client/hooks/useOfferCreation.ts
@@ -155,25 +155,26 @@ export function useOfferCreation() {
   }, []);
 
   // Step 2: League selection
-  const toggleLeague = useCallback((leagueId: string) => {
+  const toggleLeague = useCallback((leagueId: string | number) => {
     setState((prev) => {
       const { selectedLeagueIds } = prev.step2;
+      const idStr = String(leagueId);
       return {
         ...prev,
         step2: {
           ...prev.step2,
-          selectedLeagueIds: selectedLeagueIds.includes(leagueId)
-            ? selectedLeagueIds.filter((id) => id !== leagueId)
-            : [...selectedLeagueIds, leagueId],
+          selectedLeagueIds: selectedLeagueIds.includes(idStr)
+            ? selectedLeagueIds.filter((id) => id !== idStr)
+            : [...selectedLeagueIds, idStr],
         },
       };
     });
   }, []);
 
-  const setSelectedLeagues = useCallback((leagueIds: string[]) => {
+  const setSelectedLeagues = useCallback((leagueIds: Array<string | number>) => {
     setState((prev) => ({
       ...prev,
-      step2: { ...prev.step2, selectedLeagueIds: leagueIds },
+      step2: { ...prev.step2, selectedLeagueIds: leagueIds.map(String) },
     }));
   }, []);
 

--- a/src/server/routers/finance/offers.ts
+++ b/src/server/routers/finance/offers.ts
@@ -14,12 +14,23 @@ import { offerSendQueue } from '../../jobs/queue';
 
 const DEFAULT_BASE_RATE = 50;
 
-const normalizeOffer = (doc: any) => ({
-  ...doc.toObject?.() || doc,
-  _id: doc._id?.toString(),
-  associationId: doc.associationId?.toString() || doc.associationId,
-  contactId: doc.contactId?.toString?.() || doc.contactId,
-});
+const normalizeOffer = (doc: any) => {
+  const obj = doc.toObject?.() || doc;
+  
+  // Handle potentially populated fields
+  const normalizeId = (val: any) => {
+    if (!val) return val;
+    if (typeof val === 'object' && val._id) return val._id.toString();
+    return val.toString();
+  };
+
+  return {
+    ...obj,
+    _id: obj._id?.toString(),
+    associationId: normalizeId(obj.associationId),
+    contactId: normalizeId(obj.contactId),
+  };
+};
 
 const normalizeConfig = (doc: any) => ({
   ...(doc.toObject?.() || doc),


### PR DESCRIPTION
This PR fixes preselection issues in the Unified Offer Edit experience.

### Bug Fixes
- **Contact Preselection & Validation:** Fixed backend normalization of populated `contactId` and `associationId` fields to ensure they return string IDs. This resolves the `Cast to ObjectId failed` error and ensures the correct contact is selected in the UI.
- **League Preselection:** Resolved a type mismatch in the frontend where numeric IDs from the server were being compared against string IDs in the wizard state.

Verified with unit and integration tests.