### PR TITLE
fix: restore google drive folder integration and add global settings

### DIFF
--- a/shared/schemas/financialSettings.ts
+++ b/shared/schemas/financialSettings.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export const FinancialSettingsSchema = z.object({
   defaultRatePerTeamSeason: z.number().min(0),
   defaultRatePerTeamGameday: z.number().min(0),
+  defaultDriveFolderId: z.string().optional(),
 });
 
 export const UpdateFinancialSettingsSchema = FinancialSettingsSchema;

--- a/src/client/components/Offer/SendOfferDialog.tsx
+++ b/src/client/components/Offer/SendOfferDialog.tsx
@@ -1,4 +1,5 @@
 import React, { useState, useCallback, useRef, useEffect } from 'react';
+import { trpc } from '../../lib/trpc';
 
 interface SendOfferDialogProps {
   open: boolean;
@@ -28,10 +29,21 @@ export function SendOfferDialog({
   onSuccess,
   onError,
 }: SendOfferDialogProps) {
+  const { data: settings } = trpc.finance.settings.get.useQuery(undefined, { enabled: open });
+  const { data: folders = [] } = trpc.google.listFolders.useQuery(undefined, { enabled: open });
+
   const [selectedFolderId, setSelectedFolderId] = useState<string>('');
+  const [showFolderPicker, setShowFolderPicker] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [progress, setProgress] = useState<JobProgress | null>(null);
   const pollIntervalRef = useRef<NodeJS.Timeout | null>(null);
+
+  // Initialize selectedFolderId with default from settings
+  useEffect(() => {
+    if (settings?.defaultDriveFolderId && !selectedFolderId) {
+      setSelectedFolderId(settings.defaultDriveFolderId);
+    }
+  }, [settings, selectedFolderId]);
 
   // Cleanup polling interval on component unmount
   useEffect(() => {
@@ -40,13 +52,6 @@ export function SendOfferDialog({
         clearInterval(pollIntervalRef.current);
       }
     };
-  }, []);
-
-  const handleSelectFolder = useCallback(async () => {
-    // This would integrate with Google Drive Picker API
-    // For now, show a placeholder
-    console.log('Opening Drive folder picker...');
-    // In production, initialize Google Drive Picker here
   }, []);
 
   const handleSend = useCallback(async () => {
@@ -60,7 +65,7 @@ export function SendOfferDialog({
 
     try {
       // Call tRPC sendOffer mutation
-      const response = await fetch('/trpc/offersSend.sendOffer', {
+      const response = await fetch('/trpc/finance.offersSend.sendOffer', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({
@@ -89,7 +94,7 @@ export function SendOfferDialog({
         attempts++;
 
         try {
-          const statusResponse = await fetch('/trpc/offersSend.getOfferSendStatus', {
+          const statusResponse = await fetch('/trpc/finance.offersSend.getOfferSendStatus', {
             method: 'POST',
             headers: { 'Content-Type': 'application/json' },
             body: JSON.stringify({ offerId }),
@@ -159,6 +164,8 @@ export function SendOfferDialog({
     'failed': 'Failed',
   };
 
+  const selectedFolderName = folders.find(f => f.id === selectedFolderId)?.name || 'None selected';
+
   return (
     <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
       <div className="bg-white rounded-lg p-6 max-w-md w-full shadow-xl">
@@ -175,20 +182,41 @@ export function SendOfferDialog({
 
         {!progress ? (
           <>
-            <button
-              onClick={handleSelectFolder}
-              disabled={isLoading}
-              className="w-full bg-blue-600 text-white py-2 px-4 rounded mb-4 hover:bg-blue-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition"
-            >
-              {selectedFolderId ? '✓ Folder Selected' : 'Select Drive Folder'}
-            </button>
+            <div className="mb-4">
+              <label className="block text-sm font-medium text-gray-700 mb-1">
+                Target Drive Folder
+              </label>
+              {showFolderPicker ? (
+                <select
+                  value={selectedFolderId}
+                  onChange={(e) => {
+                    setSelectedFolderId(e.target.value);
+                    setShowFolderPicker(false);
+                  }}
+                  className="w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500"
+                >
+                  <option value="">Select a folder...</option>
+                  {folders.map((f) => (
+                    <option key={f.id} value={f.id}>{f.name}</option>
+                  ))}
+                </select>
+              ) : (
+                <div 
+                  onClick={() => !isLoading && setShowFolderPicker(true)}
+                  className={`flex justify-between items-center p-2 border rounded cursor-pointer hover:bg-gray-50 ${isLoading ? 'opacity-50 pointer-events-none' : ''}`}
+                >
+                  <span className="text-sm truncate mr-2">{selectedFolderName}</span>
+                  <span className="text-blue-600 text-xs font-medium">Change</span>
+                </div>
+              )}
+            </div>
 
             <button
               onClick={handleSend}
               disabled={!selectedFolderId || isLoading}
               className="w-full bg-green-600 text-white py-2 px-4 rounded hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition"
             >
-              Send
+              Send Offer
             </button>
           </>
         ) : (
@@ -213,7 +241,7 @@ export function SendOfferDialog({
           disabled={isLoading}
           className="w-full mt-4 text-gray-600 hover:text-gray-800 disabled:text-gray-400 transition py-2"
         >
-          {isLoading ? 'Sending...' : 'Close'}
+          {isLoading ? 'Processing...' : 'Close'}
         </button>
       </div>
     </div>

--- a/src/client/pages/SettingsPage.tsx
+++ b/src/client/pages/SettingsPage.tsx
@@ -6,15 +6,18 @@ export function SettingsPage() {
   const navigate = useNavigate();
   const { data: me } = trpc.auth.me.useQuery();
   const { data: settings, refetch } = trpc.finance.settings.get.useQuery();
+  const { data: folders = [] } = trpc.google.listFolders.useQuery();
   const updateSettings = trpc.finance.settings.update.useMutation({ onSuccess: () => refetch() });
 
   const [ratePerSeason, setRatePerSeason] = useState('');
   const [ratePerGameday, setRatePerGameday] = useState('');
+  const [defaultFolderId, setDefaultFolderId] = useState('');
 
   useEffect(() => {
     if (settings) {
       setRatePerSeason(String(settings.defaultRatePerTeamSeason));
       setRatePerGameday(String(settings.defaultRatePerTeamGameday));
+      setDefaultFolderId(settings.defaultDriveFolderId || '');
     }
   }, [settings]);
 
@@ -35,6 +38,7 @@ export function SettingsPage() {
     updateSettings.mutate({
       defaultRatePerTeamSeason: Number(ratePerSeason),
       defaultRatePerTeamGameday: Number(ratePerGameday),
+      defaultDriveFolderId: defaultFolderId || undefined,
     });
   }
 
@@ -49,7 +53,7 @@ export function SettingsPage() {
       </button>
       <h1 style={{ marginBottom: 'var(--spacing-xl)', fontSize: '1.5rem', color: 'var(--primary-color)' }}>Global Settings</h1>
 
-      <section className="card" style={{ background: 'var(--bg-secondary)' }}>
+      <section className="card" style={{ background: 'var(--bg-secondary)', marginBottom: 'var(--spacing-lg)' }}>
         <h2 style={{ margin: '0 0 var(--spacing-lg) 0', fontSize: 'var(--font-size-lg)' }}>Default Rates</h2>
         <form onSubmit={handleSubmit} style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-lg)' }}>
           <label className="form-group" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-xs)' }}>
@@ -62,7 +66,6 @@ export function SettingsPage() {
               onChange={(e) => setRatePerSeason(e.target.value)}
               className="form-control"
             />
-            <small style={{ color: 'var(--text-muted)' }}>Used for FLAT fee calculations when no override is present.</small>
           </label>
 
           <label className="form-group" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-xs)' }}>
@@ -75,7 +78,22 @@ export function SettingsPage() {
               onChange={(e) => setRatePerGameday(e.target.value)}
               className="form-control"
             />
-            <small style={{ color: 'var(--text-muted)' }}>Used for usage-based calculations when no override is present.</small>
+          </label>
+
+          <h2 style={{ margin: 'var(--spacing-md) 0 var(--spacing-sm) 0', fontSize: 'var(--font-size-lg)' }}>Google Drive</h2>
+          <label className="form-group" style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-xs)' }}>
+            <span style={{ fontSize: 'var(--font-size-sm)', fontWeight: 'var(--font-weight-semibold)' }}>Default Offer Folder</span>
+            <select
+              value={defaultFolderId}
+              onChange={(e) => setDefaultFolderId(e.target.value)}
+              className="form-control"
+            >
+              <option value="">Select a folder...</option>
+              {folders.map(f => (
+                <option key={f.id} value={f.id}>{f.name}</option>
+              ))}
+            </select>
+            <small style={{ color: 'var(--text-muted)' }}>Offers will be uploaded to this folder by default.</small>
           </label>
 
           <button

--- a/src/server/models/FinancialSettings.ts
+++ b/src/server/models/FinancialSettings.ts
@@ -3,11 +3,13 @@ import { Schema, model, Document } from 'mongoose';
 export interface IFinancialSettings extends Document {
   defaultRatePerTeamSeason: number;
   defaultRatePerTeamGameday: number;
+  defaultDriveFolderId?: string;
 }
 
 const FinancialSettingsSchema = new Schema<IFinancialSettings>({
   defaultRatePerTeamSeason: { type: Number, default: 0, min: 0 },
   defaultRatePerTeamGameday: { type: Number, default: 0, min: 0 },
+  defaultDriveFolderId: { type: String },
 });
 
 export const FinancialSettings = model<IFinancialSettings>('FinancialSettings', FinancialSettingsSchema);

--- a/src/server/routers/finance/settings.ts
+++ b/src/server/routers/finance/settings.ts
@@ -8,6 +8,7 @@ export const settingsRouter = router({
     return {
       defaultRatePerTeamSeason: settings.defaultRatePerTeamSeason,
       defaultRatePerTeamGameday: settings.defaultRatePerTeamGameday,
+      defaultDriveFolderId: settings.defaultDriveFolderId,
     };
   }),
 
@@ -20,6 +21,7 @@ export const settingsRouter = router({
           $set: {
             defaultRatePerTeamSeason: input.defaultRatePerTeamSeason,
             defaultRatePerTeamGameday: input.defaultRatePerTeamGameday,
+            defaultDriveFolderId: input.defaultDriveFolderId,
           },
         },
         { upsert: true }
@@ -27,6 +29,7 @@ export const settingsRouter = router({
       return {
         defaultRatePerTeamSeason: input.defaultRatePerTeamSeason,
         defaultRatePerTeamGameday: input.defaultRatePerTeamGameday,
+        defaultDriveFolderId: input.defaultDriveFolderId,
       };
     }),
 });

--- a/src/server/routers/google.ts
+++ b/src/server/routers/google.ts
@@ -1,0 +1,18 @@
+import { z } from 'zod';
+import { TRPCError } from '@trpc/server';
+import { router, adminProcedure } from '../trpc';
+import { DriveService } from '../services/DriveService';
+
+export const googleRouter = router({
+  listFolders: adminProcedure.query(async ({ ctx }) => {
+    if (!ctx.accessToken) {
+      throw new TRPCError({
+        code: 'UNAUTHORIZED',
+        message: 'No Google OAuth access token found. Please re-login.',
+      });
+    }
+
+    const driveService = new DriveService(ctx.accessToken);
+    return await driveService.listFolders();
+  }),
+});

--- a/src/server/routers/index.ts
+++ b/src/server/routers/index.ts
@@ -1,6 +1,7 @@
 import { router } from '../trpc';
 import { authRouter } from './auth';
 import { teamsRouter } from './teams';
+import { googleRouter } from './google';
 import { settingsRouter } from './finance/settings';
 import { configsRouter } from './finance/configs';
 import { discountsRouter } from './finance/discounts';
@@ -18,6 +19,7 @@ export const appRouter = router({
   health: healthRouter,
   auth: authRouter,
   teams: teamsRouter,
+  google: googleRouter,
   finance: router({
     settings: settingsRouter,
     configs: configsRouter,

--- a/src/server/services/DriveService.ts
+++ b/src/server/services/DriveService.ts
@@ -72,4 +72,21 @@ export class DriveService {
       throw new Error(`Failed to validate folder: ${err.message}`);
     }
   }
+
+  async listFolders(): Promise<Array<{ id: string; name: string }>> {
+    try {
+      const response = await this.drive.files.list({
+        q: "mimeType='application/vnd.google-apps.folder' and trashed=false",
+        fields: 'files(id, name)',
+        orderBy: 'name',
+      });
+
+      return (response.data.files || []).map((f) => ({
+        id: f.id || '',
+        name: f.name || 'Untitled Folder',
+      }));
+    } catch (err: any) {
+      throw new Error(`Failed to list folders: ${err.message}`);
+    }
+  }
 }

--- a/src/server/trpc.ts
+++ b/src/server/trpc.ts
@@ -3,6 +3,7 @@ import * as trpcExpress from '@trpc/server/adapters/express';
 import jwt from 'jsonwebtoken';
 import type { JwtPayload } from '../../shared/types';
 import { JwtPayloadSchema } from '../../shared/schemas/user';
+import { User } from './models/User';
 
 export interface Context {
   user: JwtPayload | null;
@@ -16,7 +17,7 @@ export function createInnerTRPCContext(partial: Partial<Context> = {}): Context 
   };
 }
 
-export function createContext({ req }: trpcExpress.CreateExpressContextOptions): Context {
+export async function createContext({ req }: trpcExpress.CreateExpressContextOptions): Promise<Context> {
   // Try to get token from Authorization header first (for backwards compatibility)
   let token: string | undefined;
 
@@ -34,9 +35,9 @@ export function createContext({ req }: trpcExpress.CreateExpressContextOptions):
     const verifiedPayload = jwt.verify(token, process.env.JWT_SECRET!, { algorithms: ['HS256'] });
     const payload = JwtPayloadSchema.parse(verifiedPayload);
 
-    // Extract access token from cookies or Authorization header
-    const accessToken = (req.cookies as Record<string, string>)?.access_token ||
-                       req.headers.authorization?.replace('Bearer ', '');
+    // Fetch user from DB to get the Google access token
+    const userDoc = await User.findById(payload.userId).lean();
+    const accessToken = userDoc?.googleAccessToken;
 
     return { user: payload, accessToken };
   } catch {


### PR DESCRIPTION
This PR fixes the Google Drive integration which was partially implemented with placeholders.

### Key Changes
- **Token Retrieval:** Fixed `createContext` in `trpc.ts` to fetch the Google access token from the database instead of trying to read it from (non-existent) cookies.
- **Global Settings:** Added `defaultDriveFolderId` to Financial Settings, allowing admins to set a default upload target for all offers.
- **Folder Selection:** Implemented a new `google.listFolders` query and updated the `SendOfferDialog` to allow selecting a target folder from a dropdown (defaulting to the global setting).
- **Service Updates:** Added `listFolders` to `DriveService` to support the new UI features.

Verified with a full production build.