### PR TITLE
fix: resolve CI failures in SendOfferDialog tests

### DIFF
--- a/src/client/components/Offer/__tests__/SendOfferDialog.test.tsx
+++ b/src/client/components/Offer/__tests__/SendOfferDialog.test.tsx
@@ -1,7 +1,26 @@
-import { describe, it, expect, vi } from 'vitest';
+import { describe, it, expect, vi, beforeEach } from 'vitest';
 import { render, screen } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { SendOfferDialog } from '../SendOfferDialog';
+import { trpc } from '../../../lib/trpc';
+
+// Mock trpc
+vi.mock('../../../lib/trpc', () => ({
+  trpc: {
+    finance: {
+      settings: {
+        get: {
+          useQuery: vi.fn(),
+        },
+      },
+    },
+    google: {
+      listFolders: {
+        useQuery: vi.fn(),
+      },
+    },
+  },
+}));
 
 describe('SendOfferDialog', () => {
   const mockProps = {
@@ -15,9 +34,27 @@ describe('SendOfferDialog', () => {
     onError: vi.fn(),
   };
 
+  beforeEach(() => {
+    vi.clearAllMocks();
+    
+    // Default mock returns
+    vi.mocked(trpc.finance.settings.get.useQuery).mockReturnValue({
+      data: { defaultDriveFolderId: 'folder-1' },
+      isLoading: false,
+    } as any);
+    
+    vi.mocked(trpc.google.listFolders.useQuery).mockReturnValue({
+      data: [
+        { id: 'folder-1', name: 'Offers 2026' },
+        { id: 'folder-2', name: 'Archive' },
+      ],
+      isLoading: false,
+    } as any);
+  });
+
   it('renders when open prop is true', () => {
     render(<SendOfferDialog {...mockProps} />);
-    expect(screen.getByText('Send Offer')).toBeInTheDocument();
+    expect(screen.getByRole('heading', { name: /Send Offer/i })).toBeInTheDocument();
   });
 
   it('displays recipient and total information', () => {
@@ -27,8 +64,14 @@ describe('SendOfferDialog', () => {
   });
 
   it('disables send button when no folder selected', () => {
+    // Override mock to have no folder selected
+    vi.mocked(trpc.finance.settings.get.useQuery).mockReturnValue({
+      data: { defaultDriveFolderId: '' },
+      isLoading: false,
+    } as any);
+
     render(<SendOfferDialog {...mockProps} />);
-    const sendButton = screen.getByRole('button', { name: /Send/ });
+    const sendButton = screen.getByRole('button', { name: /Send Offer/i });
     expect(sendButton).toBeDisabled();
   });
 
@@ -47,14 +90,15 @@ describe('SendOfferDialog', () => {
     expect(onClose).toHaveBeenCalled();
   });
 
-  it('displays select folder button', () => {
+  it('displays select folder information', () => {
     render(<SendOfferDialog {...mockProps} />);
-    expect(screen.getByRole('button', { name: /Select Drive Folder/ })).toBeInTheDocument();
+    expect(screen.getByText('Target Drive Folder')).toBeInTheDocument();
+    expect(screen.getByText('Offers 2026')).toBeInTheDocument();
   });
 
-  it('shows send button is disabled initially', () => {
+  it('shows send button is enabled when default folder is present', () => {
     render(<SendOfferDialog {...mockProps} />);
-    const sendButton = screen.getByRole('button', { name: /Send/ });
-    expect(sendButton).toBeDisabled();
+    const sendButton = screen.getByRole('button', { name: /Send Offer/ });
+    expect(sendButton).not.toBeDisabled();
   });
 });


### PR DESCRIPTION
This PR fixes the CI failures introduced by the Google Drive integration changes.

### Fixes
- **tRPC Mocking:** Added tRPC mocks to `SendOfferDialog.test.tsx` to provide context and data for the newly added `settings.get` and `google.listFolders` queries.
- **Selector Ambiguity:** Updated test selectors to use specific roles (heading/button) to resolve ambiguity caused by multiple elements containing the text 'Send Offer'.

Verified locally with `npm test`.