### PR TITLE
fix(drive): upload PDF as a readable stream

### DIFF
--- a/src/server/services/DriveService.ts
+++ b/src/server/services/DriveService.ts
@@ -1,4 +1,5 @@
 import { google, drive_v3 } from 'googleapis';
+import { Readable } from 'stream';
 
 export interface UploadResult {
   fileId: string;
@@ -28,7 +29,7 @@ export class DriveService {
         },
         media: {
           mimeType: 'application/pdf',
-          body: fileBuffer as any,
+          body: Readable.from(fileBuffer),
         },
         fields: 'id, webViewLink',
       });

--- a/src/server/services/__tests__/DriveService.test.ts
+++ b/src/server/services/__tests__/DriveService.test.ts
@@ -73,7 +73,7 @@ describe('DriveService', () => {
       });
     });
 
-    it('uploads file with correct parameters', async () => {
+    it('uploads file with correct parameters and a readable stream body', async () => {
       const mockFileBuffer = Buffer.from('PDF content');
       const mockResponse = {
         data: {
@@ -86,18 +86,17 @@ describe('DriveService', () => {
 
       await driveService.uploadFile(mockFileBuffer, 'test.pdf', 'folder-123');
 
-      expect(mockCreate).toHaveBeenCalledWith({
-        requestBody: {
-          name: 'test.pdf',
-          mimeType: 'application/pdf',
-          parents: ['folder-123'],
-        },
-        media: {
-          mimeType: 'application/pdf',
-          body: mockFileBuffer,
-        },
-        fields: 'id, webViewLink',
+      const arg = mockCreate.mock.calls[0][0];
+      expect(arg.requestBody).toEqual({
+        name: 'test.pdf',
+        mimeType: 'application/pdf',
+        parents: ['folder-123'],
       });
+      expect(arg.media.mimeType).toBe('application/pdf');
+      expect(arg.fields).toBe('id, webViewLink');
+      // googleapis requires a readable stream for media.body, not a Buffer
+      expect(typeof arg.media.body.pipe).toBe('function');
+      expect(Buffer.isBuffer(arg.media.body)).toBe(false);
     });
 
     it('throws error if fileId is missing from response', async () => {


### PR DESCRIPTION
Fixes `Drive upload failed: part.body.pipe is not a function`, hit during the prod offer-filing E2E once PDF generation started working (pdfkit, v0.6.0).

`DriveService.uploadFile` passed the PDF **Buffer** as googleapis `media.body`, but googleapis v173 expects a **Readable stream** (it calls `.pipe()`). Now wraps it with `Readable.from(fileBuffer)`.

TDD: updated the `uploadFile` test (which previously asserted the Buffer body) to require a stream body; red → green. Full suite 220 green; typecheck + typecheck:server pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)