### PR TITLE
fix(offer): make File-in-Drive dialog reflect the real job result

### DIFF
--- a/src/client/components/Offer/FileOfferDialog.tsx
+++ b/src/client/components/Offer/FileOfferDialog.tsx
@@ -164,25 +164,45 @@ export function FileOfferDialog({
   const selectedFolderName = folders.find(f => f.id === selectedFolderId)?.name || 'None selected';
 
   return (
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-lg p-6 max-w-md w-full shadow-xl">
-        <h2 className="text-xl font-bold mb-4">Create offer in Drive</h2>
+    <div style={{
+      position: 'fixed',
+      top: 0,
+      left: 0,
+      right: 0,
+      bottom: 0,
+      background: 'rgba(0,0,0,0.5)',
+      display: 'flex',
+      alignItems: 'center',
+      justifyContent: 'center',
+      zIndex: 1100,
+      padding: '1rem',
+      backdropFilter: 'blur(2px)',
+    }}>
+      <div className="card" style={{ width: '100%', maxWidth: '500px', maxHeight: '90vh', overflow: 'auto', padding: 'var(--spacing-xl)' }}>
+        <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', marginBottom: 'var(--spacing-lg)' }}>
+          <h2 style={{ margin: 0, fontSize: 'var(--font-size-xl)' }}>Create offer in Drive</h2>
+          <button className="btn btn-ghost btn-sm" onClick={onClose} disabled={isLoading}>✕</button>
+        </div>
 
-        <div className="bg-gray-50 p-4 rounded mb-4 space-y-2">
-          <p>
-            <span className="font-semibold">For:</span> {recipientName}
+        <div style={{
+          background: 'var(--bg-secondary)',
+          padding: 'var(--spacing-md)',
+          borderRadius: 'var(--border-radius-md)',
+          marginBottom: 'var(--spacing-lg)',
+          border: '1px solid var(--border-color)',
+        }}>
+          <p style={{ margin: '0 0 var(--spacing-xs) 0', fontSize: 'var(--font-size-md)' }}>
+            <span style={{ fontWeight: 'var(--font-weight-semibold)' }}>For:</span> {recipientName}
           </p>
-          <p>
-            <span className="font-semibold">Total:</span> €{totalPrice.toFixed(2)}
+          <p style={{ margin: 0, fontSize: 'var(--font-size-md)' }}>
+            <span style={{ fontWeight: 'var(--font-weight-semibold)' }}>Total:</span> €{totalPrice.toFixed(2)}
           </p>
         </div>
 
         {!progress ? (
           <>
-            <div className="mb-4">
-              <label className="block text-sm font-medium text-gray-700 mb-1">
-                Target Drive Folder
-              </label>
+            <div style={{ marginBottom: 'var(--spacing-lg)' }}>
+              <label className="form-label">Target Drive Folder</label>
               {showFolderPicker ? (
                 <select
                   value={selectedFolderId}
@@ -190,7 +210,7 @@ export function FileOfferDialog({
                     setSelectedFolderId(e.target.value);
                     setShowFolderPicker(false);
                   }}
-                  className="w-full border border-gray-300 rounded-md shadow-sm p-2 focus:ring-blue-500 focus:border-blue-500"
+                  className="form-control"
                 >
                   <option value="">Select a folder...</option>
                   {folders.map((f) => (
@@ -200,10 +220,24 @@ export function FileOfferDialog({
               ) : (
                 <div
                   onClick={() => !isLoading && setShowFolderPicker(true)}
-                  className={`flex justify-between items-center p-2 border rounded cursor-pointer hover:bg-gray-50 ${isLoading ? 'opacity-50 pointer-events-none' : ''}`}
+                  style={{
+                    display: 'flex',
+                    justifyContent: 'space-between',
+                    alignItems: 'center',
+                    padding: '10px 12px',
+                    border: '1px solid var(--border-color)',
+                    borderRadius: 'var(--border-radius-md)',
+                    cursor: isLoading ? 'not-allowed' : 'pointer',
+                    background: isLoading ? 'var(--bg-secondary)' : 'var(--bg-primary)',
+                    opacity: isLoading ? 0.5 : 1,
+                  }}
                 >
-                  <span className="text-sm truncate mr-2">{selectedFolderName}</span>
-                  <span className="text-blue-600 text-xs font-medium">Change</span>
+                  <span style={{ fontSize: 'var(--font-size-md)', overflow: 'hidden', textOverflow: 'ellipsis', whiteSpace: 'nowrap', marginRight: 'var(--spacing-sm)' }}>
+                    {selectedFolderName}
+                  </span>
+                  <span style={{ color: 'var(--primary-color)', fontSize: 'var(--font-size-xs)', fontWeight: 'var(--font-weight-medium)', whiteSpace: 'nowrap' }}>
+                    Change
+                  </span>
                 </div>
               )}
             </div>
@@ -211,23 +245,35 @@ export function FileOfferDialog({
             <button
               onClick={handleSend}
               disabled={!selectedFolderId || isLoading}
-              className="w-full bg-green-600 text-white py-2 px-4 rounded hover:bg-green-700 disabled:bg-gray-400 disabled:cursor-not-allowed transition"
+              className="btn btn-primary"
+              style={{ width: '100%', background: 'var(--success-color)' }}
             >
               Create in Drive
             </button>
           </>
         ) : (
-          <div className="space-y-3">
-            <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 'var(--spacing-md)' }}>
+            <div style={{
+              width: '100%',
+              background: 'var(--bg-secondary)',
+              borderRadius: '999px',
+              height: '8px',
+              overflow: 'hidden',
+              border: '1px solid var(--border-color)',
+            }}>
               <div
-                className="bg-green-600 h-full transition-all duration-300"
-                style={{ width: `${progress.percentage}%` }}
+                style={{
+                  width: `${progress.percentage}%`,
+                  height: '100%',
+                  background: progress.stage === 'failed' ? 'var(--danger-color)' : 'var(--success-color)',
+                  transition: 'width 300ms ease',
+                }}
               />
             </div>
-            <p className="text-center text-sm font-medium text-gray-700">
+            <p style={{ textAlign: 'center', fontSize: 'var(--font-size-md)', fontWeight: 'var(--font-weight-medium)', color: 'var(--text-main)', margin: 0 }}>
               {stageText[progress.stage]}
             </p>
-            <p className="text-center text-xs text-gray-500">
+            <p style={{ textAlign: 'center', fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)', margin: 0 }}>
               {progress.percentage}%
             </p>
           </div>
@@ -236,7 +282,8 @@ export function FileOfferDialog({
         <button
           onClick={onClose}
           disabled={isLoading}
-          className="w-full mt-4 text-gray-600 hover:text-gray-800 disabled:text-gray-400 transition py-2"
+          className="btn btn-ghost"
+          style={{ width: '100%', marginTop: 'var(--spacing-lg)' }}
         >
           {isLoading ? 'Processing...' : 'Close'}
         </button>

--- a/src/client/components/Offer/FileOfferDialog.tsx
+++ b/src/client/components/Offer/FileOfferDialog.tsx
@@ -78,7 +78,8 @@ export function FileOfferDialog({
       }
 
       const data = await response.json();
-      const { result } = data;
+      // tRPC wraps procedure output as { result: { data: <output> } }
+      const result = data?.result?.data;
 
       if (!result?.jobId) {
         throw new Error('No job ID returned');
@@ -107,7 +108,7 @@ export function FileOfferDialog({
           }
 
           const statusData = await statusResponse.json();
-          const { result: statusResult } = statusData;
+          const statusResult = statusData?.result?.data;
 
           if (!statusResult) {
             throw new Error('No status returned');

--- a/src/client/components/Offer/__tests__/FileOfferDialog.test.tsx
+++ b/src/client/components/Offer/__tests__/FileOfferDialog.test.tsx
@@ -1,6 +1,6 @@
 // src/client/components/Offer/__tests__/FileOfferDialog.test.tsx
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
 import { FileOfferDialog } from '../FileOfferDialog';
 
 vi.mock('../../../lib/trpc', () => ({
@@ -28,5 +28,37 @@ describe('FileOfferDialog', () => {
     render(<FileOfferDialog {...baseProps} />);
     expect(screen.getByText('Invoices 2026')).toBeTruthy();
     expect(screen.getByRole('button', { name: /Create in Drive/i })).toBeTruthy();
+  });
+
+  it('reads the jobId from the tRPC { result: { data } } envelope and completes on success', async () => {
+    // tRPC (non-batched) wraps procedure output as { result: { data: <output> } }.
+    const fetchMock = vi.fn((url: string) => {
+      if (url.includes('fileOfferInDrive')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ result: { data: { jobId: 'job-1', status: 'queued' } } }),
+        });
+      }
+      if (url.includes('getOfferDriveStatus')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            result: { data: { status: 'completed', progress: 100, driveLink: 'https://drive.google.com/file/d/abc/view' } },
+          }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const props = { ...baseProps, onSuccess: vi.fn(), onError: vi.fn() };
+    render(<FileOfferDialog {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /Create in Drive/i }));
+
+    await waitFor(
+      () => expect(props.onSuccess).toHaveBeenCalledWith('https://drive.google.com/file/d/abc/view'),
+      { timeout: 4000 }
+    );
+    expect(props.onError).not.toHaveBeenCalled();
   });
 });

--- a/src/client/pages/OfferDetailPage.tsx
+++ b/src/client/pages/OfferDetailPage.tsx
@@ -277,7 +277,7 @@ export function OfferDetailPage() {
           open={showSendDialog}
           offerId={id}
           recipientName={data?.contact?.name || 'Unknown Contact'}
-          totalPrice={data?.offer?.pricing?.expectedPrice || 0}
+          totalPrice={totalPrice}
           onClose={() => setShowSendDialog(false)}
           onSuccess={() => {
             setShowSendDialog(false);


### PR DESCRIPTION
## Summary

Fixes the **File-in-Drive** dialog freezing at "Pending… 0%" with a console error `No job ID returned`, even when the backend successfully queues and completes the Drive filing job.

Surfaced during the first live production test on `finance.leaguesphere.app` while filing offer for customer 10007 (American Football Verband Bayern e.V.).

### Root cause
`FileOfferDialog` issues raw `fetch` calls to the tRPC endpoints and read the response as `data.result.jobId` / `data.result`. tRPC wraps procedure output as `{ result: { data: <output> } }`, so `result.jobId` was always `undefined` → the dialog threw `No job ID returned` and never started polling. The backend job (`offer-drive` queue) had actually queued and completed — the offer was filed and a real PDF landed in Drive — but the UI never reflected it.

### Fix
Read `data.result.data` for both the queue mutation (`fileOfferInDrive`) and the status poll (`getOfferDriveStatus`).

### Not a bug (verified during triage)
The backend Drive upload (`DriveService`, `part.body.pipe`) was **already fixed** by #251 (`Readable.from` instead of a raw Buffer) and is deployed. The stale failures seen in Redis predate the current image; a fresh job completed successfully (offer `status: sent`, live "Open in Drive" link). No backend change needed; `DriveService.test.ts` already guards the Buffer regression.

## Tests
- New regression test drives the full click → poll → `onSuccess` flow against a correctly-shaped tRPC envelope. Verified RED (times out stuck at "Pending… 0%") before the fix, GREEN after.
- Full suite: 221 passed / 39 files. Client + server typecheck clean.

## Notes
- This branch also carries `656f2e1` (earlier: render the dialog as a styled modal + total wiring).
- Recommended rollout: deploy to `servyy-test.lxd` first, verify the dialog end-to-end, then production.

🤖 Generated with [Claude Code](https://claude.com/claude-code)