### PR TITLE
fix(offers): restore filter tabs, list total, actions, and document link

### DIFF
--- a/src/client/components/OfferTable.tsx
+++ b/src/client/components/OfferTable.tsx
@@ -68,22 +68,9 @@ export function OfferTable({
     return 0;
   });
 
-  if (filteredOffers.length === 0) {
-    return (
-      <div className="card" style={{
-        padding: 'var(--spacing-xl)',
-        textAlign: 'center',
-        background: 'var(--bg-secondary)',
-        color: 'var(--text-muted)',
-      }}>
-        <p>{filterStatus ? `No ${filterStatus} offers found.` : 'No offers found. Create one to get started.'}</p>
-      </div>
-    );
-  }
-
   return (
     <div>
-      {/* Filter Buttons */}
+      {/* Filter Buttons — always rendered so an empty filter result never hides the tabs */}
       <div style={{ marginBottom: 'var(--spacing-lg)', display: 'flex', gap: 'var(--spacing-sm)', flexWrap: 'wrap' }}>
         {[
           { label: 'All', value: null },
@@ -102,7 +89,17 @@ export function OfferTable({
         ))}
       </div>
 
-      {/* Table */}
+      {filteredOffers.length === 0 ? (
+        <div className="card" style={{
+          padding: 'var(--spacing-xl)',
+          textAlign: 'center',
+          background: 'var(--bg-secondary)',
+          color: 'var(--text-muted)',
+        }}>
+          <p>{filterStatus ? `No ${filterStatus} offers found.` : 'No offers found. Create one to get started.'}</p>
+        </div>
+      ) : (
+      /* Table */
       <div style={{ opacity: isLoading ? 0.6 : 1, pointerEvents: isLoading ? 'none' : 'auto' }}>
         <table className="mobile-cards-table" style={{
           width: '100%',
@@ -163,7 +160,7 @@ export function OfferTable({
               >
                 Status {sortBy === 'status' ? '↓' : ''}
               </th>
-              <th style={{ padding: 'var(--spacing-lg)', textAlign: 'center', fontSize: 'var(--font-size-sm)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--text-main)', borderBottom: '1px solid var(--border-color)' }}>Delete</th>
+              <th style={{ padding: 'var(--spacing-lg)', textAlign: 'center', fontSize: 'var(--font-size-sm)', fontWeight: 'var(--font-weight-semibold)', color: 'var(--text-main)', borderBottom: '1px solid var(--border-color)' }}>Actions</th>
             </tr>
           </thead>
           <tbody>
@@ -187,32 +184,65 @@ export function OfferTable({
                 <td data-label="Status" style={{ padding: 'var(--spacing-lg)', fontSize: 'var(--font-size-md)' }}>
                   <div style={statusBadgeStyle(offer.status)}>{offer.status}</div>
                 </td>
-                <td data-label="Delete" style={{ padding: 'var(--spacing-lg)', textAlign: 'center' }}>
-                  {offer.status === 'draft' && onDelete && (
+                <td data-label="Actions" style={{ padding: 'var(--spacing-lg)', textAlign: 'center' }}>
+                  <div style={{ display: 'inline-flex', alignItems: 'center', gap: 'var(--spacing-xs)', justifyContent: 'center' }}>
                     <button
                       onClick={(e) => {
                         e.stopPropagation();
-                        onDelete(offer._id);
+                        onView(offer._id);
                       }}
-                      className="btn btn-ghost btn-sm"
-                      style={{ color: 'var(--danger-color)', padding: '4px', minWidth: 'auto', minHeight: 'auto' }}
-                      title="Delete Offer"
+                      className="btn btn-outline btn-sm"
+                      style={{ padding: '4px 8px', minWidth: 'auto', minHeight: 'auto' }}
+                      title="View Offer"
                     >
-                      <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
-                        <path d="M3 6h18"></path>
-                        <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path>
-                        <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
-                        <line x1="10" y1="11" x2="10" y2="17"></line>
-                        <line x1="14" y1="11" x2="14" y2="17"></line>
-                      </svg>
+                      View
                     </button>
-                  )}
+                    {offer.driveMetadata?.driveFileId && (
+                      <a
+                        href={offer.driveMetadata.driveLink || `https://drive.google.com/file/d/${offer.driveMetadata.driveFileId}/view`}
+                        target="_blank"
+                        rel="noopener noreferrer"
+                        onClick={(e) => e.stopPropagation()}
+                        className="btn btn-ghost btn-sm"
+                        style={{ padding: '4px', minWidth: 'auto', minHeight: 'auto' }}
+                        title="Open offer document"
+                      >
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M14 2H6a2 2 0 0 0-2 2v16a2 2 0 0 0 2 2h12a2 2 0 0 0 2-2V8z"></path>
+                          <polyline points="14 2 14 8 20 8"></polyline>
+                          <line x1="16" y1="13" x2="8" y2="13"></line>
+                          <line x1="16" y1="17" x2="8" y2="17"></line>
+                          <polyline points="10 9 9 9 8 9"></polyline>
+                        </svg>
+                      </a>
+                    )}
+                    {offer.status === 'draft' && onDelete && (
+                      <button
+                        onClick={(e) => {
+                          e.stopPropagation();
+                          onDelete(offer._id);
+                        }}
+                        className="btn btn-ghost btn-sm"
+                        style={{ color: 'var(--danger-color)', padding: '4px', minWidth: 'auto', minHeight: 'auto' }}
+                        title="Delete Offer"
+                      >
+                        <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="2" strokeLinecap="round" strokeLinejoin="round">
+                          <path d="M3 6h18"></path>
+                          <path d="M19 6v14c0 1-1 2-2 2H7c-1 0-2-1-2-2V6"></path>
+                          <path d="M8 6V4c0-1 1-2 2-2h4c1 0 2 1 2 2v2"></path>
+                          <line x1="10" y1="11" x2="10" y2="17"></line>
+                          <line x1="14" y1="11" x2="14" y2="17"></line>
+                        </svg>
+                      </button>
+                    )}
+                  </div>
                 </td>
               </tr>
             ))}
           </tbody>
         </table>
       </div>
+      )}
     </div>
   );
 }

--- a/src/client/components/__tests__/OfferTable.test.tsx
+++ b/src/client/components/__tests__/OfferTable.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest';
-import { render, screen, fireEvent } from '@testing-library/react';
+import { render, screen, fireEvent, within } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { OfferTable } from '../OfferTable';
 import { Offer } from '../../lib/schemas';
@@ -197,5 +197,70 @@ describe('OfferTable', () => {
 
     const seasonElements = screen.getAllByText(/Season/i);
     expect(seasonElements.length).toBeGreaterThan(0);
+  });
+
+  it('keeps filter buttons visible when a filter yields no results', () => {
+    render(
+      <OfferTable
+        offers={mockOffers}
+        associationNames={mockAssociationNames}
+        onView={mockOnView}
+      />
+    );
+
+    // Filter to "Accepted" — none of the mock offers are accepted
+    fireEvent.click(screen.getByRole('button', { name: /Accepted/i }));
+
+    expect(screen.getByText(/No accepted offers found/i)).toBeInTheDocument();
+    // The filter tabs must remain so the user can switch back
+    expect(screen.getByRole('button', { name: /All/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Draft/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Sent/i })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Accepted/i })).toBeInTheDocument();
+
+    // And switching back to a populated filter restores the list
+    fireEvent.click(screen.getByRole('button', { name: /Sent/i }));
+    expect(screen.getByText('Association 2')).toBeInTheDocument();
+  });
+
+  it('calls onView when the row View button is clicked', async () => {
+    const user = userEvent.setup();
+    render(
+      <OfferTable
+        offers={mockOffers}
+        associationNames={mockAssociationNames}
+        onView={mockOnView}
+      />
+    );
+
+    const row = screen.getByText('Association 1').closest('tr')!;
+    await user.click(within(row).getByTitle('View Offer'));
+
+    expect(mockOnView).toHaveBeenCalledWith('1');
+  });
+
+  it('shows an open-document link only for offers with a filed drive document', () => {
+    const offersWithDoc: Offer[] = [
+      mockOffers[0],
+      {
+        ...mockOffers[1],
+        driveMetadata: {
+          driveFileId: 'file-123',
+          driveLink: 'https://drive.google.com/file/d/file-123/view',
+        },
+      },
+    ];
+
+    render(
+      <OfferTable
+        offers={offersWithDoc}
+        associationNames={mockAssociationNames}
+        onView={mockOnView}
+      />
+    );
+
+    const docLinks = screen.getAllByTitle('Open offer document');
+    expect(docLinks.length).toBe(1);
+    expect(docLinks[0]).toHaveAttribute('href', 'https://drive.google.com/file/d/file-123/view');
   });
 });

--- a/src/client/lib/schemas.ts
+++ b/src/client/lib/schemas.ts
@@ -67,6 +67,7 @@ export const OfferSchema = z.object({
   sendJobId: z.string().optional(),
   sendJobAttempts: z.number().optional(),
   driveMetadata: DriveMetadataSchema.optional(),
+  totalPrice: z.number().optional(),
 });
 
 export type Offer = z.infer<typeof OfferSchema>;

--- a/src/client/pages/OfferDetailPage.tsx
+++ b/src/client/pages/OfferDetailPage.tsx
@@ -260,9 +260,9 @@ export function OfferDetailPage() {
             {markAccepted.isPending ? '…' : '✓ Mark as Accepted'}
           </button>
         )}
-        {offer.status === 'sent' && offer.driveMetadata?.driveFileId && (
+        {(offer.status === 'sent' || offer.status === 'accepted') && offer.driveMetadata?.driveFileId && (
           <a
-            href={`https://drive.google.com/file/d/${offer.driveMetadata.driveFileId}/view`}
+            href={offer.driveMetadata.driveLink || `https://drive.google.com/file/d/${offer.driveMetadata.driveFileId}/view`}
             target="_blank"
             rel="noopener noreferrer"
             className="btn btn-primary"

--- a/src/server/routers/finance/offers.ts
+++ b/src/server/routers/finance/offers.ts
@@ -75,7 +75,21 @@ export const offersRouter = router({
         .sort({ createdAt: -1 })
         .lean();
 
-      return offers.map(normalizeOffer);
+      // Compute each offer's total from its FinancialConfigs. The Offer document
+      // itself carries no price; pricing lives in FinancialConfig records.
+      const offerIds = offers.map((o: any) => o._id);
+      const configs = await FinancialConfig.find({ offerId: { $in: offerIds } }).lean();
+      const totalByOfferId = configs.reduce((acc: Record<string, number>, config: any) => {
+        const { finalPrice } = computeConfigPrices(config);
+        const key = config.offerId?.toString?.() || config.offerId;
+        acc[key] = (acc[key] || 0) + finalPrice;
+        return acc;
+      }, {});
+
+      return offers.map((offer: any) => ({
+        ...normalizeOffer(offer),
+        totalPrice: totalByOfferId[offer._id?.toString()] || 0,
+      }));
     }),
 
   get: protectedProcedure


### PR DESCRIPTION
## Summary

Fixes four issues on the Offers list/detail pages, reproduced live on finance.leaguesphere.app (v0.6.6).

| # | Issue | Root cause | Fix |
|---|-------|-----------|-----|
| 1 | Filter tabs vanish when a filter has 0 results | Empty-state early return rendered *before* the filter bar | Filter bar always renders; empty state shows beneath it |
| 2 | List "Total Revenue" shows 0 | `offers.list` returned offers with no price; client summed an undefined `totalPrice` | Endpoint computes each offer's total from its `FinancialConfig`s |
| 3 | No link to offer document | Detail page showed "Open in Drive" only for `sent` offers | Now shown for `sent` **or** `accepted` (guarded by `driveFileId`), preferring stored `driveLink` |
| 4 | Action buttons missing | Earlier refactor removed the row actions dropdown | Added per-row **View** + **open-document** link (filed offers) alongside draft-only Delete |

## Testing

- ✅ `npm run typecheck` (client) and `npm run typecheck:server` — clean
- ✅ `OfferTable` tests: 13 passed, incl. 3 new regression tests (filter persistence, View button, open-document link)
- ✅ `OfferSummaryCards` + server `offers` model tests pass

## Notes

- Verified against the live accepted offer's real data (`driveMetadata.driveFileId` + `driveLink` present), so the document link now appears on both the detail page and the list row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)