### PR TITLE
fix(offers): send resolved prices with the Drive filing job so the PDF isn't 0 €

### DIFF
--- a/src/server/jobs/FileOfferJob.ts
+++ b/src/server/jobs/FileOfferJob.ts
@@ -1,7 +1,6 @@
 import { Job } from 'bull';
 import { Offer } from '../models/Offer';
 import { Contact } from '../models/Contact';
-import { FinancialConfig } from '../models/FinancialConfig';
 import { Association } from '../models/Association';
 import { PdfService, PdfGenerationData } from '../services/PdfService';
 import { DriveService } from '../services/DriveService';
@@ -12,11 +11,13 @@ export interface FileOfferJobData {
   userId: string;
   driveFolderId: string;
   accessToken: string;
+  /** Line items with prices already resolved at enqueue time; the PDF only renders them. */
+  configs: any[];
 }
 
 export class FileOfferJobHandler {
   static async process(job: Job<FileOfferJobData>) {
-    const { offerId, driveFolderId, accessToken } = job.data;
+    const { offerId, driveFolderId, accessToken, configs } = job.data;
 
     try {
       job.progress(10);
@@ -30,8 +31,6 @@ export class FileOfferJobHandler {
 
       const association = await Association.findById(offer.associationId);
       const associationName = association?.name || 'Unknown Association';
-
-      const configs = await FinancialConfig.find({ offerId }).lean();
 
       let leaguesMap: Record<number, string> = {};
       try {

--- a/src/server/jobs/__tests__/FileOfferJob.test.ts
+++ b/src/server/jobs/__tests__/FileOfferJob.test.ts
@@ -18,7 +18,10 @@ vi.mock('../../services/DriveService');
 vi.mock('../../db/mysql');
 
 const makeJob = () => ({
-  data: { offerId: 'o1', userId: 'u1', driveFolderId: 'fold1', accessToken: 'ya29.x' },
+  data: {
+    offerId: 'o1', userId: 'u1', driveFolderId: 'fold1', accessToken: 'ya29.x',
+    configs: [{ leagueId: 16, expectedTeamsCount: 1, finalPrice: 50 }],
+  },
   progress: vi.fn(),
   log: vi.fn(),
 });
@@ -51,6 +54,26 @@ describe('FileOfferJobHandler', () => {
     const res = await FileOfferJobHandler.process(makeJob() as any);
     expect(mockUpload).toHaveBeenCalledWith(expect.any(Buffer), 'offer.pdf', 'fold1');
     expect(res).toEqual({ success: true, driveLink: 'https://drive/file1' });
+  });
+
+  it('forwards the priced configs from the job payload to the PDF and does not query FinancialConfig', async () => {
+    const save = vi.fn();
+    vi.mocked(Offer.findById).mockResolvedValue({ _id: 'o1', contactId: 'c1', associationId: 'a1', save } as any);
+    const job = {
+      data: {
+        offerId: 'o1', userId: 'u1', driveFolderId: 'fold1', accessToken: 'ya29.x',
+        configs: [{ leagueId: 16, expectedTeamsCount: 2, finalPrice: 100 }],
+      },
+      progress: vi.fn(),
+      log: vi.fn(),
+    };
+    await FileOfferJobHandler.process(job as any);
+    expect(PdfService.generateOfferPdf).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configs: [expect.objectContaining({ leagueId: 16, expectedTeamsCount: 2, finalPrice: 100 })],
+      })
+    );
+    expect(FinancialConfig.find).not.toHaveBeenCalled();
   });
 
   it('on success sets status=sent and writes driveMetadata', async () => {

--- a/src/server/lib/__tests__/configPricing.test.ts
+++ b/src/server/lib/__tests__/configPricing.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect } from 'vitest';
+import { computeConfigPrices, DEFAULT_BASE_RATE } from '../configPricing';
+
+const seasonConfig = (over: Record<string, any> = {}) => ({
+  leagueId: 16,
+  costModel: 'SEASON',
+  baseRateOverride: null,
+  customPrice: null,
+  expectedTeamsCount: 3,
+  expectedGamedaysCount: 0,
+  expectedTeamsPerGameday: 0,
+  ...over,
+});
+
+describe('computeConfigPrices', () => {
+  it('SEASON basePrice = baseRate * expectedTeamsCount and finalPrice follows it', () => {
+    const r = computeConfigPrices(seasonConfig());
+    expect(r.basePrice).toBe(DEFAULT_BASE_RATE * 3);
+    expect(r.finalPrice).toBe(DEFAULT_BASE_RATE * 3);
+  });
+
+  it('baseRateOverride replaces the default base rate', () => {
+    const r = computeConfigPrices(seasonConfig({ baseRateOverride: 80 }));
+    expect(r.basePrice).toBe(80 * 3);
+    expect(r.finalPrice).toBe(80 * 3);
+  });
+
+  it('customPrice overrides the computed basePrice for finalPrice', () => {
+    const r = computeConfigPrices(seasonConfig({ customPrice: 120 }));
+    expect(r.basePrice).toBe(DEFAULT_BASE_RATE * 3);
+    expect(r.finalPrice).toBe(120);
+  });
+
+  it('GAMEDAY basePrice = baseRate * expectedGamedaysCount * expectedTeamsPerGameday', () => {
+    const r = computeConfigPrices(
+      seasonConfig({ costModel: 'GAMEDAY', expectedGamedaysCount: 4, expectedTeamsPerGameday: 2 })
+    );
+    expect(r.basePrice).toBe(DEFAULT_BASE_RATE * 4 * 2);
+    expect(r.finalPrice).toBe(DEFAULT_BASE_RATE * 4 * 2);
+  });
+
+  it('carries the league name through when provided', () => {
+    const r = computeConfigPrices(seasonConfig(), 'RL Bayern');
+    expect(r.leagueName).toBe('RL Bayern');
+  });
+});

--- a/src/server/lib/configPricing.ts
+++ b/src/server/lib/configPricing.ts
@@ -1,0 +1,24 @@
+export const DEFAULT_BASE_RATE = 50;
+
+/**
+ * Derives pricing fields (`basePrice`, `finalPrice`) from a stored FinancialConfig.
+ *
+ * These fields are NOT persisted on the model — they are computed on read. Any
+ * surface that renders prices (offer detail, list totals, the offer PDF) must run
+ * configs through this function first; passing a raw config yields `finalPrice`
+ * === undefined, which downstream renders as 0,00 €.
+ */
+export const computeConfigPrices = (config: any, leagueName: string = 'Unknown League') => {
+  const baseRate = config.baseRateOverride ?? DEFAULT_BASE_RATE;
+  const basePrice = config.costModel === 'SEASON'
+    ? baseRate * config.expectedTeamsCount
+    : baseRate * config.expectedGamedaysCount * config.expectedTeamsPerGameday;
+
+  return {
+    ...config,
+    basePrice: Math.round(basePrice * 100) / 100,
+    customPrice: config.customPrice ?? null,
+    finalPrice: config.customPrice != null ? config.customPrice : Math.round(basePrice * 100) / 100,
+    leagueName: leagueName,
+  };
+};

--- a/src/server/routers/finance/__tests__/offers-drive.test.ts
+++ b/src/server/routers/finance/__tests__/offers-drive.test.ts
@@ -1,15 +1,23 @@
 import { describe, it, expect, beforeEach, vi } from 'vitest';
 import { Offer } from '../../../models/Offer';
+import { FinancialConfig } from '../../../models/FinancialConfig';
 import { offerDriveQueue } from '../../../jobs/queue';
 import { offersDriveRouter } from '../offers-drive';
 
 vi.mock('../../../models/Offer');
+vi.mock('../../../models/FinancialConfig');
 vi.mock('../../../jobs/queue', () => ({ offerDriveQueue: { add: vi.fn(), getJob: vi.fn() } }));
 
 const ctx = { user: { userId: 'u1', email: 'a@bumbleflies.de', role: 'admin' as const }, accessToken: 'ya29.x' };
 const caller = () => offersDriveRouter.createCaller(ctx as any);
 
-beforeEach(() => vi.clearAllMocks());
+const mockConfigs = (configs: any[]) =>
+  vi.mocked(FinancialConfig.find).mockReturnValue({ lean: () => Promise.resolve(configs) } as any);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockConfigs([]); // default: no configs unless a test overrides
+});
 
 describe('offersDrive.fileOfferInDrive', () => {
   it('rejects when offer is not draft', async () => {
@@ -35,6 +43,25 @@ describe('offersDrive.fileOfferInDrive', () => {
       expect.any(Object)
     );
     expect(res.status).toBe('queued');
+  });
+
+  it('sends priced configs (finalPrice computed) with the job so the PDF never calculates', async () => {
+    const save = vi.fn();
+    vi.mocked(Offer.findById).mockResolvedValue({ status: 'draft', save } as any);
+    mockConfigs([
+      { leagueId: 16, costModel: 'SEASON', baseRateOverride: null, customPrice: null,
+        expectedTeamsCount: 2, expectedGamedaysCount: 0, expectedTeamsPerGameday: 0 },
+    ]);
+    vi.mocked(offerDriveQueue.add as any).mockResolvedValue({ id: 7 });
+
+    await caller().fileOfferInDrive({ offerId: 'o1', driveFolderId: 'f1' });
+
+    expect(offerDriveQueue.add).toHaveBeenCalledWith(
+      expect.objectContaining({
+        configs: [expect.objectContaining({ leagueId: 16, expectedTeamsCount: 2, finalPrice: 100 })],
+      }),
+      expect.any(Object)
+    );
   });
 });
 

--- a/src/server/routers/finance/offers-drive.ts
+++ b/src/server/routers/finance/offers-drive.ts
@@ -2,6 +2,8 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { adminProcedure, router } from '../../trpc';
 import { Offer } from '../../models/Offer';
+import { FinancialConfig } from '../../models/FinancialConfig';
+import { computeConfigPrices } from '../../lib/configPricing';
 import { offerDriveQueue } from '../../jobs/queue';
 
 const JOB_OPTS = {
@@ -9,6 +11,15 @@ const JOB_OPTS = {
   backoff: { type: 'exponential' as const, delay: 2000 },
   removeOnComplete: true,
   removeOnFail: false,
+};
+
+/**
+ * Build the offer's line items with prices resolved. Prices travel with the job
+ * so the PDF renderer only formats numbers — it never calculates them.
+ */
+const buildPricedConfigs = async (offerId: string) => {
+  const configs = await FinancialConfig.find({ offerId }).lean();
+  return configs.map((config) => computeConfigPrices(config));
 };
 
 export const offersDriveRouter = router({
@@ -24,8 +35,9 @@ export const offersDriveRouter = router({
         throw new TRPCError({ code: 'UNAUTHORIZED', message: 'No Google OAuth access token found' });
       }
 
+      const configs = await buildPricedConfigs(input.offerId);
       const job = await offerDriveQueue.add(
-        { offerId: input.offerId, userId: ctx.user.userId, driveFolderId: input.driveFolderId, accessToken: ctx.accessToken },
+        { offerId: input.offerId, userId: ctx.user.userId, driveFolderId: input.driveFolderId, accessToken: ctx.accessToken, configs },
         JOB_OPTS
       );
 
@@ -92,8 +104,9 @@ export const offersDriveRouter = router({
         throw new TRPCError({ code: 'BAD_REQUEST', message: 'No Drive folder information found' });
       }
 
+      const configs = await buildPricedConfigs(input.offerId);
       const job = await offerDriveQueue.add(
-        { offerId: input.offerId, userId: ctx.user.userId, driveFolderId, accessToken: ctx.accessToken },
+        { offerId: input.offerId, userId: ctx.user.userId, driveFolderId, accessToken: ctx.accessToken, configs },
         JOB_OPTS
       );
 

--- a/src/server/routers/finance/offers.ts
+++ b/src/server/routers/finance/offers.ts
@@ -10,8 +10,7 @@ import { Contact } from '../../models/Contact';
 import { getMysqlPool } from '../../db/mysql';
 import { supportsTransactions } from '../../db/mongo';
 import { extractContactInfo } from '../../../../shared/lib/extraction';
-
-const DEFAULT_BASE_RATE = 50;
+import { computeConfigPrices } from '../../lib/configPricing';
 
 const normalizeOffer = (doc: any) => {
   const obj = doc.toObject?.() || doc;
@@ -41,21 +40,6 @@ const normalizeContact = (doc: any) => ({
   ...doc,
   _id: doc._id?.toString(),
 });
-
-const computeConfigPrices = (config: any, leagueName: string = 'Unknown League') => {
-  const baseRate = config.baseRateOverride ?? DEFAULT_BASE_RATE;
-  const basePrice = config.costModel === 'SEASON'
-    ? baseRate * config.expectedTeamsCount
-    : baseRate * config.expectedGamedaysCount * config.expectedTeamsPerGameday;
-
-  return {
-    ...config,
-    basePrice: Math.round(basePrice * 100) / 100,
-    customPrice: config.customPrice ?? null,
-    finalPrice: config.customPrice != null ? config.customPrice : Math.round(basePrice * 100) / 100,
-    leagueName: leagueName,
-  };
-};
 
 export const offersRouter = router({
   list: protectedProcedure


### PR DESCRIPTION
## Problem

The generated offer PDF (e.g. `Angebot_...6a43eddb...`) showed **0,00 €** for every league and the total, even though the offer detail page showed correct prices.

## Root cause

The PDF is produced by the `FileOfferJob` worker, which passed **raw** `FinancialConfig` documents straight to `PdfService`. `finalPrice`/`basePrice` are **computed on read** via `computeConfigPrices`, not stored on the model — so `c.finalPrice` was `undefined` and `euro(undefined || 0)` rendered `0,00 €` on every row and the total. The *Teams* column looked right only because `expectedTeamsCount` **is** a stored field. The web detail route was correct because it runs configs through `computeConfigPrices`; the PDF path never did.

This is the same computed-price logic PR #263 restored for the list/detail routes — the PDF job was the remaining surface reading a field only those routes produced.

## Fix

Prices are computed **once, at enqueue time**, and carried in the job payload. The PDF layer only renders numbers now — it never calculates.

- **New** `src/server/lib/configPricing.ts` — extracted `computeConfigPrices` + `DEFAULT_BASE_RATE` into a single source of truth (detail route, list totals, PDF).
- `offers.ts` imports from the lib (no behavior change).
- `offers-drive.ts` — builds priced line-items and includes them in the job payload for both the **file** and **retry** paths.
- `FileOfferJob.ts` — forwards `job.data.configs` to the PDF; no query, no calculation.
- `PdfService.ts` — **unchanged** (already only renders).

## Tests

TDD, red→green for each step. Full suite: **231 passed**; client + server typecheck clean.

- `configPricing` unit tests (SEASON/GAMEDAY/override/customPrice).
- `offers-drive` test asserting the job payload carries computed `finalPrice`.
- `FileOfferJob` test asserting it forwards payload configs and never queries `FinancialConfig`.

## Note

The already-filed PDF for the existing `sent` offer won't fix itself — regenerating it needs a re-file, and only `draft` offers can be filed. Handling that specific offer is out of scope for this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)