### PR TITLE
fix(dashboard): resolve current season and use per-league offer pricing

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,8 @@
 # Agent Instructions: Leagues Finance
 
+## Deployment
+- **Production URL**: https://finance.leaguesphere.app/ (deployed via the `container` repo).
+
 ## Architecture & Boundaries
 - **Client**: `src/client/` (React + Vite + tRPC Client). Entry: `src/client/main.tsx`.
 - **Server**: `src/server/` (Express + tRPC Server + tsx). Entry: `src/server/index.ts`.

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 A standalone financial dashboard for managing league revenues, discounts, and configurations.
 
+**Production**: https://finance.leaguesphere.app/
+
 ## Tech Stack
 
 - **Frontend**: React 19, Vite, tRPC Client, TanStack Query.

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -69,7 +69,7 @@ export function App() {
                     <Route path="/associations" element={<AssociationsPage />} />
                     <Route path="/contacts" element={<ContactsPage />} />
                   </Route>
-                  <Route path="/config*" element={<Navigate to="/dashboard" replace />} />
+                  <Route path="/config/*" element={<Navigate to="/dashboard" replace />} />
                   <Route path="*" element={<Navigate to="/dashboard" replace />} />
                 </Routes>
               </div>

--- a/src/client/components/AssociationList.tsx
+++ b/src/client/components/AssociationList.tsx
@@ -76,17 +76,22 @@ export function AssociationList({ associations, onEdit, onDelete, isLoading = fa
                 </svg>
               </button>
             </div>
-            {association.address ? (
-              <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--text-muted)', lineHeight: '1.5' }}>
-                {association.address.street}<br />
-                {association.address.city}, {association.address.postalCode}<br />
-                {association.address.country}
-              </div>
-            ) : (
-              <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--text-muted)', fontStyle: 'italic' }}>
-                No address provided
-              </div>
-            )}
+            {(() => {
+              const addr = association.address;
+              const cityLine = [addr?.city, addr?.postalCode].filter(Boolean).join(', ');
+              const hasAddress = Boolean(addr && (addr.street || cityLine || addr.country));
+              return hasAddress ? (
+                <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--text-muted)', lineHeight: '1.5' }}>
+                  {addr!.street && <>{addr!.street}<br /></>}
+                  {cityLine && <>{cityLine}<br /></>}
+                  {addr!.country}
+                </div>
+              ) : (
+                <div style={{ fontSize: 'var(--font-size-sm)', color: 'var(--text-muted)', fontStyle: 'italic' }}>
+                  No address provided
+                </div>
+              );
+            })()}
           </div>
           <div style={{ marginTop: 'var(--spacing-md)', fontSize: 'var(--font-size-xs)', color: 'var(--text-muted)', fontStyle: 'italic' }}>
             Click to edit

--- a/src/client/components/__tests__/AssociationList.test.tsx
+++ b/src/client/components/__tests__/AssociationList.test.tsx
@@ -53,6 +53,25 @@ describe('AssociationList', () => {
     expect(screen.getByText(/City 1/i)).toBeInTheDocument();
   });
 
+  it('shows "No address provided" for an address with only empty fields', () => {
+    const emptyAddr: Association[] = [
+      {
+        _id: '3',
+        name: 'Empty Address Assoc',
+        address: { street: '', postalCode: '', city: '', country: '' },
+        createdAt: new Date(),
+        updatedAt: new Date(),
+      },
+    ];
+    const { container } = render(
+      <AssociationList associations={emptyAddr} onEdit={mockOnEdit} onDelete={mockOnDelete} />
+    );
+
+    expect(screen.getByText(/No address provided/i)).toBeInTheDocument();
+    // No stray comma from an empty "city, postalCode" line.
+    expect(container.textContent).not.toContain(',');
+  });
+
   it('calls onEdit when a card is clicked', () => {
     render(<AssociationList associations={mockAssociations} onEdit={mockOnEdit} onDelete={mockOnDelete} />);
 

--- a/src/client/lib/__tests__/dashboardUtils.test.ts
+++ b/src/client/lib/__tests__/dashboardUtils.test.ts
@@ -1,5 +1,12 @@
 import { describe, it, expect } from 'vitest';
-import { groupDashboardData } from '../dashboardUtils';
+import {
+  groupDashboardData,
+  selectCurrentSeason,
+  computeGrossRevenue,
+  buildActiveContracts,
+  buildMissingContracts,
+  type DashboardOffer,
+} from '../dashboardUtils';
 
 describe('groupDashboardData', () => {
   it('groups configured and pending items by season', () => {
@@ -20,5 +27,104 @@ describe('groupDashboardData', () => {
     expect(result[1].seasonId).toBe(1);
     expect(result[1].rows).toHaveLength(2);
     expect(result[1].totalGross).toBe(100);
+  });
+});
+
+// Real season shape returned by teams.seasons: { id, name, slug } — no `_id`, no `year`.
+const SEASONS = [
+  { id: 6, name: '2026', slug: '2026' },
+  { id: 5, name: '2025', slug: '2025' },
+  { id: 4, name: '2024', slug: '2024' },
+];
+
+// Real offer shape returned by finance.offers.list: carries `totalPrice` plus a
+// per-league `leaguePrices` breakdown (RL Bayern 560 + Bayern U16 280 = 840).
+const ACCEPTED_OFFER: DashboardOffer = {
+  _id: 'offer1',
+  status: 'accepted',
+  seasonId: 6,
+  leagueIds: [16, 29],
+  associationId: 'assoc1',
+  totalPrice: 840,
+  leaguePrices: [
+    { leagueId: 16, finalPrice: 560 },
+    { leagueId: 29, finalPrice: 280 },
+  ],
+};
+
+const LEAGUE_MAP = {
+  16: { name: 'RL Bayern' },
+  29: { name: 'Bayern U16' },
+  99: { name: 'Other League' },
+};
+const ASSOC_MAP = { assoc1: { name: 'AFV Bayern e.V.' } };
+
+describe('selectCurrentSeason', () => {
+  it('returns null when there are no seasons', () => {
+    expect(selectCurrentSeason([])).toBeNull();
+  });
+
+  it('picks the latest season by year regardless of input order', () => {
+    const shuffled = [SEASONS[1], SEASONS[2], SEASONS[0]];
+    expect(selectCurrentSeason(shuffled)).toEqual({ id: 6, name: '2026', slug: '2026' });
+  });
+});
+
+describe('computeGrossRevenue', () => {
+  it('sums totalPrice of revenue-bearing offers in the current season', () => {
+    expect(computeGrossRevenue([ACCEPTED_OFFER], 6)).toBe(840);
+  });
+
+  it('ignores offers from other seasons', () => {
+    expect(computeGrossRevenue([ACCEPTED_OFFER], 5)).toBe(0);
+  });
+
+  it('ignores draft offers', () => {
+    const draft = { ...ACCEPTED_OFFER, status: 'draft' };
+    expect(computeGrossRevenue([draft], 6)).toBe(0);
+  });
+
+  it('returns 0 when no season is selected', () => {
+    expect(computeGrossRevenue([ACCEPTED_OFFER], undefined)).toBe(0);
+  });
+});
+
+describe('buildActiveContracts', () => {
+  it('produces one row per contracted league with that league\'s own final price', () => {
+    const rows = buildActiveContracts([ACCEPTED_OFFER], 6, LEAGUE_MAP, ASSOC_MAP);
+    expect(rows).toHaveLength(2);
+    // Sorted by league name: Bayern U16 (280) then RL Bayern (560).
+    expect(rows.map(r => [r.leagueName, r.revenue])).toEqual([
+      ['Bayern U16', 280],
+      ['RL Bayern', 560],
+    ]);
+    expect(rows[0].assocName).toBe('AFV Bayern e.V.');
+  });
+
+  it('falls back to 0 revenue when a league has no price entry', () => {
+    const offer: DashboardOffer = { ...ACCEPTED_OFFER, leaguePrices: [] };
+    const rows = buildActiveContracts([offer], 6, LEAGUE_MAP, ASSOC_MAP);
+    expect(rows.every(r => r.revenue === 0)).toBe(true);
+  });
+
+  it('returns nothing when the season does not match', () => {
+    expect(buildActiveContracts([ACCEPTED_OFFER], 5, LEAGUE_MAP, ASSOC_MAP)).toEqual([]);
+  });
+});
+
+describe('buildMissingContracts', () => {
+  const LEAGUES = [
+    { id: 16, name: 'RL Bayern' },
+    { id: 29, name: 'Bayern U16' },
+    { id: 99, name: 'Other League' },
+  ];
+
+  it('excludes leagues already covered by an offer this season', () => {
+    const missing = buildMissingContracts([ACCEPTED_OFFER], 6, LEAGUES);
+    expect(missing.map(m => m.name)).toEqual(['Other League']);
+  });
+
+  it('treats every league as missing when no season is selected', () => {
+    expect(buildMissingContracts([ACCEPTED_OFFER], undefined, LEAGUES)).toEqual([]);
   });
 });

--- a/src/client/lib/dashboardUtils.ts
+++ b/src/client/lib/dashboardUtils.ts
@@ -1,6 +1,105 @@
 import type { FinancialConfig, CalculationResult } from '../../../shared/types';
 
-export type DashboardRow = 
+/**
+ * Offer shape as returned by `finance.offers.list`. The list endpoint attaches a
+ * per-offer `totalPrice` and a per-league `leaguePrices` breakdown, both derived
+ * from the offer's FinancialConfig records.
+ */
+export interface DashboardOffer {
+  _id: string;
+  status: string;
+  seasonId: number;
+  leagueIds: number[];
+  associationId: string;
+  totalPrice: number;
+  leaguePrices?: Array<{ leagueId: number; finalPrice: number }>;
+}
+
+export interface ActiveContractRow {
+  leagueId: number;
+  leagueName: string;
+  assocName: string;
+  status: string;
+  offerId: string;
+  revenue: number;
+}
+
+// Offer statuses that count toward tracked revenue.
+const REVENUE_STATUSES = new Set(['sent', 'accepted', 'sending']);
+
+/**
+ * Select the current season (latest year first). Seasons come from `teams.seasons`
+ * as `{ id, name, slug }` where `name` is the year string (e.g. "2026").
+ */
+export function selectCurrentSeason<T extends { name: string }>(seasons: T[]): T | null {
+  if (!seasons.length) return null;
+  return [...seasons].sort((a, b) => Number(b.name) - Number(a.name))[0];
+}
+
+/** Gross revenue = sum of `totalPrice` for revenue-bearing offers in the season. */
+export function computeGrossRevenue(offers: DashboardOffer[], seasonId: number | undefined): number {
+  if (seasonId == null) return 0;
+  return offers
+    .filter(o => o.seasonId === seasonId && REVENUE_STATUSES.has(o.status))
+    .reduce((sum, o) => sum + (o.totalPrice || 0), 0);
+}
+
+/**
+ * One row per contracted league in the season, showing that league's own
+ * `finalPrice` from the offer's per-league `leaguePrices` breakdown.
+ */
+export function buildActiveContracts(
+  offers: DashboardOffer[],
+  seasonId: number | undefined,
+  leagueMap: Record<number, { name: string }>,
+  assocMap: Record<string, { name: string }>
+): ActiveContractRow[] {
+  if (seasonId == null) return [];
+
+  const rows: ActiveContractRow[] = [];
+  const seen = new Set<number>();
+
+  offers
+    .filter(o => o.seasonId === seasonId)
+    .forEach(offer => {
+      offer.leagueIds.forEach(lId => {
+        if (seen.has(lId)) return;
+        seen.add(lId);
+        const leaguePrice = offer.leaguePrices?.find(lp => lp.leagueId === lId);
+        rows.push({
+          leagueId: lId,
+          leagueName: leagueMap[lId]?.name || `League ${lId}`,
+          assocName: assocMap[offer.associationId]?.name || 'Unknown',
+          status: offer.status,
+          offerId: offer._id,
+          revenue: leaguePrice?.finalPrice ?? 0,
+        });
+      });
+    });
+
+  return rows.sort((a, b) => a.leagueName.localeCompare(b.leagueName));
+}
+
+/** Leagues in the season that have no offer at all. */
+export function buildMissingContracts(
+  offers: DashboardOffer[],
+  seasonId: number | undefined,
+  leagues: Array<{ id: number; name: string }>
+): Array<{ id: number; name: string }> {
+  if (seasonId == null || !leagues.length) return [];
+
+  const contracted = new Set<number>();
+  offers
+    .filter(o => o.seasonId === seasonId)
+    .forEach(o => o.leagueIds.forEach(id => contracted.add(id)));
+
+  return leagues
+    .filter(l => !contracted.has(l.id))
+    .map(l => ({ id: l.id, name: l.name }))
+    .sort((a, b) => a.name.localeCompare(b.name));
+}
+
+export type DashboardRow =
   | { type: 'CONFIGURED'; config: any; stats: any }
   | { type: 'PENDING'; leagueId: number; seasonId: number; leagueName: string; seasonName: string; gamedayCount: number };
 

--- a/src/client/pages/DashboardPage.tsx
+++ b/src/client/pages/DashboardPage.tsx
@@ -2,6 +2,12 @@ import { useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { trpc } from '../lib/trpc';
 import { SummaryCards } from '../components/SummaryCards';
+import {
+  selectCurrentSeason,
+  computeGrossRevenue,
+  buildActiveContracts,
+  buildMissingContracts,
+} from '../lib/dashboardUtils';
 
 export function DashboardPage() {
   const navigate = useNavigate();
@@ -28,83 +34,27 @@ export function DashboardPage() {
   const leagueMap = useMemo(() => Object.fromEntries(leagues.map(l => [l.id, l])), [leagues]);
   const assocMap = useMemo(() => Object.fromEntries(associations.map(a => [a._id, a])), [associations]);
 
-  // Current season (latest by year)
-  const currentSeason = useMemo(() => {
-    if (!seasons.length) return null;
-    return [...seasons].sort((a, b) => b.year - a.year)[0];
-  }, [seasons]);
+  // Current season (latest by year). Seasons are { id, name, slug } where name is the year.
+  const currentSeason = useMemo(() => selectCurrentSeason(seasons), [seasons]);
 
   // Financial Stats Calculation (Current Season, Sent/Accepted/Sending)
   const stats = useMemo(() => {
-    const relevantOffers = offers.filter(o => 
-      o.seasonId === currentSeason?._id && (o.status === 'sent' || o.status === 'accepted' || o.status === 'sending')
-    );
-
-    let gross = 0;
-    let discount = 0;
-
-    relevantOffers.forEach(offer => {
-      offer.financialConfigs?.forEach((config: any) => {
-        gross += config.finalPrice || 0;
-      });
-    });
-
-    return {
-      gross,
-      discount,
-      net: gross - discount
-    };
+    const gross = computeGrossRevenue(offers, currentSeason?.id);
+    const discount = 0;
+    return { gross, discount, net: gross - discount };
   }, [offers, currentSeason]);
 
-  // Active Contracts: Leagues in current season that have ANY offer (draft, sending, sent, or accepted)
-  const activeContracts = useMemo(() => {
-    if (!currentSeason) return [];
+  // Active Contracts: Leagues in current season that have ANY offer.
+  const activeContracts = useMemo(
+    () => buildActiveContracts(offers, currentSeason?.id, leagueMap, assocMap),
+    [offers, currentSeason, leagueMap, assocMap]
+  );
 
-    const results: any[] = [];
-    const processedLeagueIds = new Set<number>();
-
-    offers
-      .filter(o => o.seasonId === currentSeason._id)
-      .forEach(offer => {
-        offer.leagueIds.forEach((lId: number) => {
-          if (!processedLeagueIds.has(lId)) {
-            const league = leagueMap[lId];
-            const assoc = assocMap[offer.associationId];
-            const config = offer.financialConfigs?.find((c: any) => c.leagueId === lId);
-            
-            results.push({
-              leagueId: lId,
-              leagueName: league?.name || `League ${lId}`,
-              assocName: assoc?.name || 'Unknown',
-              status: offer.status,
-              offerId: offer._id,
-              revenue: config?.finalPrice || 0
-            });
-            processedLeagueIds.add(lId);
-          }
-        });
-      });
-    
-    return results.sort((a, b) => a.leagueName.localeCompare(b.leagueName));
-  }, [offers, currentSeason, leagueMap, assocMap]);
-
-  // Missing Contracts: Leagues in current season that have NO offer at all
-  const missingContracts = useMemo(() => {
-    if (!currentSeason || !leagues.length) return [];
-    
-    const contractedLeagueIds = new Set<number>();
-    offers
-      .filter(o => o.seasonId === currentSeason._id)
-      .forEach(o => o.leagueIds.forEach((id: number) => contractedLeagueIds.add(id)));
-
-    return leagues
-      .filter(l => !contractedLeagueIds.has(l.id))
-      .map(l => ({
-        id: l.id,
-        name: l.name
-      }))
-      .sort((a, b) => a.name.localeCompare(b.name));
-  }, [offers, currentSeason, leagues]);
+  // Missing Contracts: Leagues in current season that have NO offer at all.
+  const missingContracts = useMemo(
+    () => buildMissingContracts(offers, currentSeason?.id, leagues),
+    [offers, currentSeason, leagues]
+  );
 
   const toggleLeagueSelection = (id: number) => {
     setSelectedMissingLeagues(prev => 
@@ -115,7 +65,7 @@ export function DashboardPage() {
   const handleCreateOfferForSelected = () => {
     if (selectedMissingLeagues.length === 0) return;
     const leagueIdsStr = selectedMissingLeagues.join(',');
-    navigate(`/offers/new?leagues=${leagueIdsStr}&season=${currentSeason?._id}`);
+    navigate(`/offers/new?leagues=${leagueIdsStr}&season=${currentSeason?.id}`);
   };
 
   if (offersLoading) return <div className="container"><p>Loading dashboard...</p></div>;
@@ -156,7 +106,7 @@ export function DashboardPage() {
           Financial Overview
         </h1>
         <p style={{ margin: '4px 0 0 0', fontSize: 'var(--font-size-sm)', color: 'var(--text-muted)' }}>
-          {currentSeason ? `Tracking Season ${currentSeason.year}` : 'No active season found'}
+          {currentSeason ? `Tracking Season ${currentSeason.name}` : 'No active season found'}
         </p>
       </header>
 

--- a/src/client/pages/SettingsPage.tsx
+++ b/src/client/pages/SettingsPage.tsx
@@ -6,7 +6,10 @@ export function SettingsPage() {
   const navigate = useNavigate();
   const { data: me } = trpc.auth.me.useQuery();
   const { data: settings, refetch } = trpc.finance.settings.get.useQuery();
-  const { data: folders = [] } = trpc.google.listFolders.useQuery();
+  const { data: folders = [], isError: foldersError } = trpc.google.listFolders.useQuery(
+    undefined,
+    { retry: false }
+  );
   const updateSettings = trpc.finance.settings.update.useMutation({ onSuccess: () => refetch() });
 
   const [ratePerSeason, setRatePerSeason] = useState('');
@@ -87,13 +90,20 @@ export function SettingsPage() {
               value={defaultFolderId}
               onChange={(e) => setDefaultFolderId(e.target.value)}
               className="form-control"
+              disabled={foldersError}
             >
               <option value="">Select a folder...</option>
               {folders.map(f => (
                 <option key={f.id} value={f.id}>{f.name}</option>
               ))}
             </select>
-            <small style={{ color: 'var(--text-muted)' }}>Offers will be uploaded to this folder by default.</small>
+            {foldersError ? (
+              <small style={{ color: 'var(--danger-color)' }}>
+                Couldn’t load Google Drive folders — your Google session may have expired. Please re-login to reconnect Drive.
+              </small>
+            ) : (
+              <small style={{ color: 'var(--text-muted)' }}>Offers will be uploaded to this folder by default.</small>
+            )}
           </label>
 
           <button

--- a/src/server/__tests__/offer-redesign.integration.test.ts
+++ b/src/server/__tests__/offer-redesign.integration.test.ts
@@ -90,6 +90,40 @@ describe('Offer Redesign Integration', () => {
     expect(configs[0].leagueId).toBe(101);
   });
 
+  it('exposes per-league prices and a matching total from offers.list', async () => {
+    const contact = await Contact.create({
+      name: 'Fabian Pawlowski',
+      email: 'f.pawlowski@afcvnrw.de',
+      address: { street: 'Teststrasse 1', city: 'Marl', postalCode: '45770', country: 'Germany' },
+    });
+
+    // baseRate 75 × 12 teams = 900 per league (SEASON model), no custom price.
+    await caller.finance.offers.create({
+      associationId: 'assoc-123',
+      contactId: contact._id.toString(),
+      seasonId: 2025,
+      leagueIds: [101, 102],
+      costModel: 'flatFee' as const,
+      baseRateOverride: 75,
+      expectedTeamsCount: 12,
+    });
+
+    const offers = await caller.finance.offers.list();
+    expect(offers).toHaveLength(1);
+
+    const [offer] = offers as any[];
+    expect(offer.totalPrice).toBe(1800);
+    expect(offer.leaguePrices).toHaveLength(2);
+
+    const byLeague = Object.fromEntries(
+      offer.leaguePrices.map((lp: any) => [lp.leagueId, lp.finalPrice])
+    );
+    expect(byLeague).toEqual({ 101: 900, 102: 900 });
+    // Per-league prices sum to the offer total.
+    const sum = offer.leaguePrices.reduce((acc: number, lp: any) => acc + lp.finalPrice, 0);
+    expect(sum).toBe(offer.totalPrice);
+  });
+
   afterAll(async () => {
     await disconnectMongo();
   });

--- a/src/server/routers/finance/offers.ts
+++ b/src/server/routers/finance/offers.ts
@@ -59,20 +59,24 @@ export const offersRouter = router({
         .sort({ createdAt: -1 })
         .lean();
 
-      // Compute each offer's total from its FinancialConfigs. The Offer document
+      // Compute each offer's pricing from its FinancialConfigs. The Offer document
       // itself carries no price; pricing lives in FinancialConfig records.
       const offerIds = offers.map((o: any) => o._id);
       const configs = await FinancialConfig.find({ offerId: { $in: offerIds } }).lean();
-      const totalByOfferId = configs.reduce((acc: Record<string, number>, config: any) => {
+
+      const totalByOfferId: Record<string, number> = {};
+      const leaguePricesByOfferId: Record<string, Array<{ leagueId: number; finalPrice: number }>> = {};
+      for (const config of configs as any[]) {
         const { finalPrice } = computeConfigPrices(config);
         const key = config.offerId?.toString?.() || config.offerId;
-        acc[key] = (acc[key] || 0) + finalPrice;
-        return acc;
-      }, {});
+        totalByOfferId[key] = (totalByOfferId[key] || 0) + finalPrice;
+        (leaguePricesByOfferId[key] ||= []).push({ leagueId: config.leagueId, finalPrice });
+      }
 
       return offers.map((offer: any) => ({
         ...normalizeOffer(offer),
         totalPrice: totalByOfferId[offer._id?.toString()] || 0,
+        leaguePrices: leaguePricesByOfferId[offer._id?.toString()] || [],
       }));
     }),
 

--- a/src/server/routers/google.ts
+++ b/src/server/routers/google.ts
@@ -13,6 +13,19 @@ export const googleRouter = router({
     }
 
     const driveService = new DriveService(ctx.accessToken);
-    return await driveService.listFolders();
+    try {
+      return await driveService.listFolders();
+    } catch (err: any) {
+      // An expired/invalid Google token surfaces as a 401 from the Drive API.
+      // Map it to UNAUTHORIZED so the client can prompt a re-login instead of
+      // treating it as a 500 server error.
+      if (err?.status === 401 || err?.status === 403) {
+        throw new TRPCError({
+          code: 'UNAUTHORIZED',
+          message: 'Google session expired. Please re-login to reconnect Google Drive.',
+        });
+      }
+      throw err;
+    }
   }),
 });

--- a/src/server/routers/teams.ts
+++ b/src/server/routers/teams.ts
@@ -2,18 +2,19 @@ import { z } from 'zod';
 import type { RowDataPacket } from 'mysql2';
 import { router, protectedProcedure } from '../trpc';
 import { getMysqlPool } from '../db/mysql';
+import type { League, Season } from '../../../shared/types';
 
 export const teamsRouter = router({
-  leagues: protectedProcedure.query(async () => {
+  leagues: protectedProcedure.query(async (): Promise<League[]> => {
     const pool = getMysqlPool();
     const [rows] = await pool.query<RowDataPacket[]>('SELECT id, name, slug FROM gamedays_league ORDER BY name');
-    return rows;
+    return rows as unknown as League[];
   }),
 
-  seasons: protectedProcedure.query(async () => {
+  seasons: protectedProcedure.query(async (): Promise<Season[]> => {
     const pool = getMysqlPool();
     const [rows] = await pool.query<RowDataPacket[]>('SELECT id, name, slug FROM gamedays_season ORDER BY name DESC');
-    return rows;
+    return rows as unknown as Season[];
   }),
 
   byLeagueSeason: protectedProcedure

--- a/src/server/services/DriveService.ts
+++ b/src/server/services/DriveService.ts
@@ -87,7 +87,11 @@ export class DriveService {
         name: f.name || 'Untitled Folder',
       }));
     } catch (err: any) {
-      throw new Error(`Failed to list folders: ${err.message}`);
+      // Preserve the HTTP status (e.g. 401 for expired/invalid credentials) so
+      // callers can distinguish an auth failure from a genuine server error.
+      const wrapped = new Error(`Failed to list folders: ${err.message}`);
+      (wrapped as any).status = err?.status ?? err?.code;
+      throw wrapped;
     }
   }
 }

--- a/src/server/services/__tests__/DriveService.test.ts
+++ b/src/server/services/__tests__/DriveService.test.ts
@@ -4,6 +4,7 @@ import { DriveService } from '../DriveService';
 const mockSetCredentials = vi.fn();
 const mockCreate = vi.fn();
 const mockGet = vi.fn();
+const mockList = vi.fn();
 
 // Mock googleapis
 vi.mock('googleapis', () => {
@@ -20,6 +21,7 @@ vi.mock('googleapis', () => {
         files: {
           create: mockCreate,
           get: mockGet,
+          list: mockList,
         },
       })),
     },
@@ -250,6 +252,40 @@ describe('DriveService', () => {
         fileId: 'folder-123',
         fields: 'id, mimeType',
       });
+    });
+  });
+
+  describe('listFolders', () => {
+    it('maps Drive folders to { id, name }', async () => {
+      mockList.mockResolvedValueOnce({
+        data: { files: [{ id: 'f1', name: 'Offers' }, { id: 'f2', name: 'Archive' }] },
+      });
+
+      const result = await driveService.listFolders();
+
+      expect(result).toEqual([
+        { id: 'f1', name: 'Offers' },
+        { id: 'f2', name: 'Archive' },
+      ]);
+    });
+
+    it('preserves the auth status (401) so callers can map expired credentials', async () => {
+      const mockError = new Error('Request had invalid authentication credentials.');
+      (mockError as any).status = 401;
+      mockList.mockRejectedValueOnce(mockError);
+
+      await expect(driveService.listFolders()).rejects.toMatchObject({
+        message: expect.stringContaining('Failed to list folders'),
+        status: 401,
+      });
+    });
+
+    it('falls back to err.code when err.status is absent', async () => {
+      const mockError = new Error('unauthorized');
+      (mockError as any).code = 401;
+      mockList.mockRejectedValueOnce(mockError);
+
+      await expect(driveService.listFolders()).rejects.toMatchObject({ status: 401 });
     });
   });
 });


### PR DESCRIPTION
## Summary

Found during full E2E testing of **v0.6.10** on prod (`finance.leaguesphere.app`). The dashboard was completely non-functional — header showed **"Tracking Season undefined"**, gross revenue / active contracts were 0, and every league (including already-contracted ones) appeared under "Missing Contracts".

### Root cause
The dashboard assumed a Mongo-style season `{ _id, year }`, but `teams.seasons` returns SQL rows `{ id, name, slug }`:
- `currentSeason.year` → `undefined` (header text)
- every filter `o.seasonId === currentSeason._id` compared against `undefined` → nothing matched
- gross summed `offer.financialConfigs`, which `offers.list` never returns (it returns `totalPrice`)

### Changes
- **Dashboard:** extract season selection + contract calculations into pure, unit-tested helpers in `dashboardUtils.ts`, keyed on `season.id`/`season.name` and offer pricing.
- **Per-league revenue:** extend `finance.offers.list` with a `leaguePrices: [{ leagueId, finalPrice }]` breakdown so Active Contracts shows each league's own price (e.g. RL Bayern 560 €, Bayern U16 280 €) rather than the offer total.
- **Types:** `teams.seasons`/`teams.leagues` now return the shared `Season`/`League` types.

### Also fixed (found in the same E2E pass)
- **Settings / Google Drive:** an expired Google token surfaced as a raw **500** on `google.listFolders`, breaking the folder dropdown. Now mapped to `UNAUTHORIZED`, and the Settings page shows a "re-login to reconnect Drive" hint instead of a silently empty dropdown.
- **Associations:** all-empty addresses rendered a stray `,`; now shows "No address provided" and drops empty city/postal lines.
- **Routing:** `/config*` → `/config/*` (React Router warning).
- **Docs:** record the production URL in `AGENTS.md` / `README.md`.

## Testing
- `npm run test` → **247 passing** (added unit tests for the dashboard helpers, a `DriveService.listFolders` auth-status test, an empty-address AssociationList test, and an integration test asserting `offers.list` returns per-league prices summing to `totalPrice`).
- `npm run typecheck` + `npm run typecheck:server` → clean.

⚠️ Not yet deployed — per repo policy this goes to `servyy-test.lxd` → approval → prod via Ansible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)