### PR TITLE
docs: capture season data shape, offer pricing, and Drive auth gotchas

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -27,9 +27,16 @@
 - **MongoDB**: Primary store for configs, discounts, and settings. 
 - **Local Dev**: If `MONGO_URI` is unset in `.env`, the server automatically starts an **in-memory MongoDB** (`mongodb-memory-server`).
 
+## Domain Data Shapes & Gotchas
+- **Seasons & leagues are SQL rows, not Mongo docs.** `teams.seasons` / `teams.leagues` return `{ id, name, slug }` (typed to the shared `Season`/`League` types). The season **`name` is the year string** (e.g. `"2026"`) — there is **no `year` field and no `_id`**. Pick the current season by `Number(season.name)` (descending) and filter offers by `season.id`. (Assuming a Mongo-style `{ _id, year }` shape caused the v0.6.10 dashboard "Tracking Season undefined" bug.)
+- **Offer pricing is never stored on the Offer document.** It lives in separate `FinancialConfig` records and is computed on read via `computeConfigPrices()` (`src/server/lib/configPricing.ts`) — passing a raw config yields `finalPrice === undefined`, which renders as `0,00 €`. Endpoint contract:
+  - `finance.offers.list` → each offer carries a derived `totalPrice` **and** a per-league `leaguePrices: [{ leagueId, finalPrice }]` breakdown. It does **not** embed `financialConfigs`.
+  - `finance.offers.get` → returns `configs` (fully priced) separately from the offer.
+
 ## Auth Flow
 - **Strategy**: Passport.js with `passport-google-oauth20`.
 - **Token**: Success redirects issue a JWT. Client uses `getToken()`/`clearToken()` in `src/client/lib/trpc.ts`.
+- **Google Drive calls use the logged-in user's OAuth access token** (`ctx.accessToken`), not a service account. When that token is missing/expired, `google.listFolders` throws **`UNAUTHORIZED`** (not a 500) so the UI can prompt a re-login — `DriveService.listFolders` preserves the Google `401/403` status for this mapping.
 
 ## Testing
 - **Suite**: Vitest.

--- a/README.md
+++ b/README.md
@@ -36,3 +36,9 @@ A standalone financial dashboard for managing league revenues, discounts, and co
 - `npm run test`: Run Vitest suites.
 - `npm run typecheck`: Client-side type checking.
 - `npm run typecheck:server`: Server-side type checking.
+
+## Domain Notes
+
+- **Seasons/leagues come from LeagueSphere's MySQL** as `{ id, name, slug }` — a season's `name` is the year (e.g. `"2026"`); there is no separate `year` field. Select the current season by the numeric `name` and match offers on `season.id`.
+- **Offer prices are not stored on the offer.** They live in `FinancialConfig` records and are computed on read (`computeConfigPrices`). `offers.list` returns a derived `totalPrice` plus a per-league `leaguePrices` breakdown.
+- **Google Drive access uses the signed-in user's OAuth token.** An expired token surfaces as an `UNAUTHORIZED` error prompting re-login (e.g. the Settings → Default Offer Folder picker).


### PR DESCRIPTION
Documents the domain knowledge behind the v0.6.10 dashboard fix (#271) so it isn't rediscovered the hard way.

- **`AGENTS.md`** — new "Domain Data Shapes & Gotchas" section (season shape `{ id, name, slug }` with `name`=year; `FinancialConfig` pricing model; `offers.list` `totalPrice` + `leaguePrices` contract) plus a Google Drive OAuth note.
- **`README.md`** — concise "Domain Notes" mirroring the same points for human readers.

Docs-only; no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)