### PR TITLE
docs: add CLAUDE.md importing AGENTS.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,11 @@
+# CLAUDE.md
+
+Guidance for Claude Code (claude.ai/code) working in the **leagues.finance** repo.
+
+This project's agent instructions live in [`AGENTS.md`](./AGENTS.md) (shared with other
+agent tooling). To keep a single source of truth, that file is imported below rather than
+duplicated here — read it in full before making changes.
+
+@AGENTS.md
+
+See also [`README.md`](./README.md) for the human-facing overview and domain notes.


### PR DESCRIPTION
`leagues.finance` was the only repo without a `CLAUDE.md`, so Claude Code didn't auto-load its guidance (the sibling `container/` and `leaguesphere/` repos both have one).

Adds a thin `CLAUDE.md` that `@`-imports `AGENTS.md` — single source of truth, no duplication — matching the workspace's import convention. Follow-up to #271/#273.

🤖 Generated with [Claude Code](https://claude.com/claude-code)