### PR TITLE
fix(offers): render season year in filed PDF instead of season id

### DIFF
--- a/src/server/jobs/FileOfferJob.ts
+++ b/src/server/jobs/FileOfferJob.ts
@@ -47,6 +47,19 @@ export class FileOfferJobHandler {
         console.warn('Failed to fetch league names:', err);
       }
 
+      // Resolve the season's display name (the year string, e.g. "2026"); fall back to the id.
+      let seasonName = `${offer.seasonId}`;
+      try {
+        const pool = getMysqlPool();
+        const [rows] = await pool.query<any[]>(
+          'SELECT name FROM gamedays_season WHERE id = ?',
+          [offer.seasonId]
+        );
+        if (rows[0]?.name != null) seasonName = `${rows[0].name}`;
+      } catch (err) {
+        console.warn('Failed to fetch season name:', err);
+      }
+
       // Step 1: Generate PDF
       job.progress(20);
       job.log('Generating PDF...');
@@ -56,7 +69,7 @@ export class FileOfferJobHandler {
         configs,
         leaguesMap,
         associationName,
-        seasonName: `${offer.seasonId}`,
+        seasonName,
       };
       const pdfBuffer = await PdfService.generateOfferPdf(pdfData);
       const filename = PdfService.generateFilename(offer._id.toString(), associationName);

--- a/src/server/jobs/__tests__/FileOfferJob.test.ts
+++ b/src/server/jobs/__tests__/FileOfferJob.test.ts
@@ -44,7 +44,12 @@ beforeEach(() => {
   vi.mocked(Contact.findById).mockResolvedValue({} as any);
   vi.mocked(Association.findById).mockResolvedValue({ name: 'AFVB' } as any);
   vi.mocked(FinancialConfig.find).mockReturnValue({ lean: () => Promise.resolve([{ leagueId: 16 }]) } as any);
-  vi.mocked(getMysqlPool).mockReturnValue({ query: () => Promise.resolve([[{ id: 16, name: 'RL Bayern' }]]) } as any);
+  vi.mocked(getMysqlPool).mockReturnValue({
+    query: (sql: string) =>
+      /gamedays_season/i.test(sql)
+        ? Promise.resolve([[{ id: 6, name: '2026' }]])
+        : Promise.resolve([[{ id: 16, name: 'RL Bayern' }]]),
+  } as any);
 });
 
 describe('FileOfferJobHandler', () => {
@@ -74,6 +79,28 @@ describe('FileOfferJobHandler', () => {
       })
     );
     expect(FinancialConfig.find).not.toHaveBeenCalled();
+  });
+
+  it('resolves the season name from gamedays_season and passes it to the PDF', async () => {
+    const save = vi.fn();
+    vi.mocked(Offer.findById).mockResolvedValue({ _id: 'o1', contactId: 'c1', associationId: 'a1', seasonId: 6, save } as any);
+    await FileOfferJobHandler.process(makeJob() as any);
+    expect(PdfService.generateOfferPdf).toHaveBeenCalledWith(
+      expect.objectContaining({ seasonName: '2026' })
+    );
+  });
+
+  it('falls back to the seasonId when the season name lookup returns nothing', async () => {
+    const save = vi.fn();
+    vi.mocked(Offer.findById).mockResolvedValue({ _id: 'o1', contactId: 'c1', associationId: 'a1', seasonId: 6, save } as any);
+    vi.mocked(getMysqlPool).mockReturnValue({
+      query: (sql: string) =>
+        /gamedays_season/i.test(sql) ? Promise.resolve([[]]) : Promise.resolve([[{ id: 16, name: 'RL Bayern' }]]),
+    } as any);
+    await FileOfferJobHandler.process(makeJob() as any);
+    expect(PdfService.generateOfferPdf).toHaveBeenCalledWith(
+      expect.objectContaining({ seasonName: '6' })
+    );
   });
 
   it('on success sets status=sent and writes driveMetadata', async () => {


### PR DESCRIPTION
## Problem
The Drive-filed offer PDF printed **"Saison 6"** (the internal `seasonId`) instead of the season year **"Saison 2026"**. Found while running the live e2e offer→PDF→Drive workflow against production (v0.6.12).

`FileOfferJob` passed `seasonName: \`${offer.seasonId}\`` straight into `PdfService`, which renders it in the subject line and body ("…für die Saison 6", "Verwaltung der Saison 6").

## Fix
Resolve the season's display name from `gamedays_season` (where `name` is the year string, e.g. `"2026"`), mirroring the existing league-name lookup in the same job. Falls back to the id if the lookup fails or returns nothing, so it never regresses to a crash.

## Tests
- New test: season name resolved from `gamedays_season` → PDF gets `seasonName: '2026'` (RED before fix).
- New test: empty lookup falls back to the id (`'6'`).
- `typecheck:server` clean; job + PdfService + offer-workflow integration suites green.

## Scope
Cosmetic/customer-facing label only — unrelated to the v0.6.12 price fix, which is confirmed working (PDF shows correct `200,00 €`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)