### PR TITLE
fix(offers): poll drive-status query with GET instead of POST

### DIFF
--- a/src/client/components/Offer/FileOfferDialog.tsx
+++ b/src/client/components/Offer/FileOfferDialog.tsx
@@ -93,11 +93,12 @@ export function FileOfferDialog({
         attempts++;
 
         try {
-          const statusResponse = await fetch('/trpc/finance.offersDrive.getOfferDriveStatus', {
-            method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
-            body: JSON.stringify({ offerId }),
-          });
+          // getOfferDriveStatus is a tRPC query; over HTTP it must be a GET
+          // with the input in the ?input= query param (a POST returns 405).
+          const statusInput = encodeURIComponent(JSON.stringify({ offerId }));
+          const statusResponse = await fetch(
+            `/trpc/finance.offersDrive.getOfferDriveStatus?input=${statusInput}`
+          );
 
           if (!statusResponse.ok) {
             if (pollIntervalRef.current) clearInterval(pollIntervalRef.current);

--- a/src/client/components/Offer/__tests__/FileOfferDialog.test.tsx
+++ b/src/client/components/Offer/__tests__/FileOfferDialog.test.tsx
@@ -61,4 +61,40 @@ describe('FileOfferDialog', () => {
     );
     expect(props.onError).not.toHaveBeenCalled();
   });
+
+  it('polls the drive-status query with GET (tRPC queries reject POST with 405)', async () => {
+    const calls: Array<{ url: string; method?: string }> = [];
+    const fetchMock = vi.fn((url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method });
+      if (url.includes('fileOfferInDrive')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({ result: { data: { jobId: 'job-1' } } }),
+        });
+      }
+      if (url.includes('getOfferDriveStatus')) {
+        return Promise.resolve({
+          ok: true,
+          json: () => Promise.resolve({
+            result: { data: { status: 'completed', progress: 100, driveLink: 'https://drive.google.com/file/d/abc/view' } },
+          }),
+        });
+      }
+      return Promise.reject(new Error(`unexpected fetch: ${url}`));
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const props = { ...baseProps, onSuccess: vi.fn(), onError: vi.fn() };
+    render(<FileOfferDialog {...props} />);
+    fireEvent.click(screen.getByRole('button', { name: /Create in Drive/i }));
+
+    await waitFor(() => expect(props.onSuccess).toHaveBeenCalled(), { timeout: 4000 });
+
+    const statusCall = calls.find((c) => c.url.includes('getOfferDriveStatus'));
+    expect(statusCall).toBeTruthy();
+    // getOfferDriveStatus is a tRPC *query*; over HTTP it only accepts GET.
+    expect((statusCall!.method ?? 'GET').toUpperCase()).toBe('GET');
+    // The input travels as an ?input= query param, not a POST body.
+    expect(statusCall!.url).toContain('input=');
+  });
 });


### PR DESCRIPTION
## Problem

The **File in Drive** progress modal (`FileOfferDialog`) polled the `finance.offersDrive.getOfferDriveStatus` tRPC **query** using HTTP **POST**. tRPC only accepts queries over **GET**, so every poll returned **405 METHOD_NOT_SUPPORTED**.

On the first poll tick the `!statusResponse.ok` branch fired → cleared the interval, stopped the spinner and raised a "Failed to check job status" error — leaving the modal **frozen at "Pending... 0%"** even though the Drive filing job (a separate mutation + background job) completed successfully.

Found during the v0.6.14 live e2e test: offer filed fine (offer went `Sent`, PDF generated with correct season + price and appeared in Drive), but the UI showed a perpetual "Pending".

## Fix

Poll with a **GET** and pass the input via the `?input=` query param — the shape tRPC queries accept over HTTP (verified returning `200` on prod). The initial `fileOfferInDrive` call is a mutation and correctly stays a POST.

## Why it wasn't caught

The existing dialog test mocked `fetch` without asserting the HTTP **method**, so a POST-vs-GET mismatch slipped through. Added a test asserting the status poll uses **GET** with an `?input=` query string.

## Verification
- New test fails on old code (`expected 'POST' to be 'GET'`), passes after the fix (RED→GREEN).
- `npm run typecheck` + `npm run typecheck:server`: clean.
- `npm run test`: **250/250 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)