### PR TITLE
fix(build): migrate tsconfig.server.json to TypeScript 7

### DIFF
--- a/.github/workflows/part_node_build.yaml
+++ b/.github/workflows/part_node_build.yaml
@@ -29,7 +29,7 @@ jobs:
           cache-dependency-path: ${{ inputs.project }}/package.json
       - name: 🔍 Run eslint ${{ inputs.project }}
         run: |
-          npm ci --legacy-peer-deps
+          npm ci
           npm run lint
       - name: 👷 Building ${{ inputs.project }}
         run: npm run build > typescript.log

--- a/tsconfig.server.json
+++ b/tsconfig.server.json
@@ -1,18 +1,16 @@
 {
   "compilerOptions": {
     "target": "ES2022",
-    "module": "CommonJS",
-    "moduleResolution": "node",
-    "ignoreDeprecations": "6.0",
+    "module": "nodenext",
+    "moduleResolution": "nodenext",
     "lib": ["ES2022"],
     "strict": true,
     "esModuleInterop": true,
     "skipLibCheck": true,
     "outDir": "dist",
-    "baseUrl": ".",
     "types": ["vitest/globals"],
     "paths": {
-      "@shared/*": ["shared/*"]
+      "@shared/*": ["./shared/*"]
     }
   },
   "include": ["src/server/**/*", "shared/**/*"],


### PR DESCRIPTION
## Problem
CI's `npm run build` fails at the `tsc -p tsconfig.server.json` step (exit 2, hidden because the workflow pipes build output to `typescript.log`). The `0.6.20` release bumped `typescript` to `^7.0.0`; a fresh `npm ci` in CI installs **TS 7.0.2**, which removed `moduleResolution: "node"`, `baseUrl`, and non-relative `paths` — all still present in the config:

```
tsconfig.server.json(5,25): error TS5108: Option 'moduleResolution=node10' has been removed.
tsconfig.server.json(12,5): error TS5102: Option 'baseUrl' has been removed.
tsconfig.server.json(15,21): error TS5090: Non-relative paths are not allowed.
```

It only passed locally on cached TS 6.0.3.

## Changes
- **`tsconfig.server.json`**: `module`/`moduleResolution` → `nodenext`, removed `baseUrl` and the obsolete `ignoreDeprecations`, made the `@shared/*` path relative. Emit stays CommonJS (package has no `"type": "module"`), so `node dist/src/server/index.js` is unaffected.
- **`.github/workflows/part_node_build.yaml`**: dropped the redundant `npm ci --legacy-peer-deps`; `.npmrc` already sets `legacy-peer-deps=true`, so it applies to CI and local installs alike.

## Verification (CI-equivalent, from committed state, TS 7.0.2)
- `npm ci` (no flag) → exit 0, `.npmrc` honored
- `npm run lint` → exit 0
- `npm run build` → exit 0, server output emitted, CommonJS
- `npm run typecheck:server` → exit 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)