### PR TITLE
chore(lint): adopt oxlint and resolve existing violations

### DIFF
--- a/.github/workflows/part_node_build.yaml
+++ b/.github/workflows/part_node_build.yaml
@@ -27,7 +27,7 @@ jobs:
           node-version: "24.x"
           cache: "npm"
           cache-dependency-path: ${{ inputs.project }}/package.json
-      - name: 🔍 Run eslint ${{ inputs.project }}
+      - name: 🔍 Run oxlint ${{ inputs.project }}
         run: |
           npm ci
           npm run lint

--- a/.oxlintrc.json
+++ b/.oxlintrc.json
@@ -1,0 +1,35 @@
+{
+  "$schema": "./node_modules/oxlint/configuration_schema.json",
+  "categories": {
+    "correctness": "error",
+    "suspicious": "warn",
+    "pedantic": "off"
+  },
+  "rules": {
+    "typescript/no-explicit-any": "off",
+    "typescript/no-namespace": "off",
+    "no-unused-vars": ["error", { "argsIgnorePattern": "^_", "varsIgnorePattern": "^_", "caughtErrorsIgnorePattern": "^_" }],
+    "no-console": ["warn", { "allow": ["warn", "error"] }],
+    "eqeqeq": ["error", "always", { "null": "ignore" }],
+    "prefer-const": "error",
+    "no-var": "error",
+    "no-underscore-dangle": "off",
+    "no-async-endpoint-handlers": "off",
+    "no-shadow": "warn"
+  },
+  "env": {
+    "browser": true,
+    "node": true,
+    "es2021": true
+  },
+  "ignorePatterns": [
+    "**/__tests__/**",
+    "src/test/**",
+    "e2e/**",
+    "node_modules/**",
+    "dist/**",
+    "coverage/**",
+    "playwright-report/**",
+    "test-results/**"
+  ]
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -58,6 +58,7 @@
         "concurrently": "^10.0.0",
         "jsdom": "^29.0.2",
         "mongodb-memory-server": "^11.0.1",
+        "oxlint": "^1.73.0",
         "tsx": "^4.21.0",
         "typescript": "^7.0.0",
         "vite": "^8.0.4",
@@ -1038,6 +1039,329 @@
         "url": "https://github.com/sponsors/Boshen"
       }
     },
+    "node_modules/@oxlint/binding-android-arm-eabi": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm-eabi/-/binding-android-arm-eabi-1.73.0.tgz",
+      "integrity": "sha512-HZQRN/UMBu+Ut+/9MiAChkbP4qZqrNOWBcNI45vOT40GVhbGR0JgHB87L48D4iAqFQIdVmeQYtV9RF89AjTKkg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-android-arm64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-android-arm64/-/binding-android-arm64-1.73.0.tgz",
+      "integrity": "sha512-Gp+KJRylv2aW7thRpG5p1KTxZq4ZJFbWowrKzufNq9d3ssl3r3JviYV45/+p+7CN1Nv0zDd1e8Ex0b/HUDq4TQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-arm64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-arm64/-/binding-darwin-arm64-1.73.0.tgz",
+      "integrity": "sha512-3de96NdtXhxERMjIz7wsp2HYMY6pMQycGxFWac2mFecAx6VeARF/IqFb1QIaqiCRIdfzBwzTed+pCTCoiS+CYA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-darwin-x64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-darwin-x64/-/binding-darwin-x64-1.73.0.tgz",
+      "integrity": "sha512-5zx/uPW32TiaOeVY1dQ/H5iOf0K1HOdFKOJhLqGl4o63+i1fpzoqqu/mKtd7OFgFjNCdhlyTGgjVkQTZm1ELcg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-freebsd-x64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-freebsd-x64/-/binding-freebsd-x64-1.73.0.tgz",
+      "integrity": "sha512-qNe4gKHaGnLuZJ8toUg90JAa0S2vTVvDw+0bRi3q1avXZXDT4u5mMeECf3nD4HYrbdn1O7dXqWut4onY/yx/Xg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-gnueabihf": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.73.0.tgz",
+      "integrity": "sha512-cCehYh5hTbfShm/fxTD6wwrGUWIpvX+N5OxmAMhFhDeTGXvw+BeNj889tpxsFQ9ZLatQ6wImuY8tsKLZ+FMz7w==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm-musleabihf": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm-musleabihf/-/binding-linux-arm-musleabihf-1.73.0.tgz",
+      "integrity": "sha512-d5j5GDU/2dMgjVhw7TQT9ITrsIr1Y02KEXKyVGIXUkD+KiaxE9TP65FS2ZdgTBemQvoRL+gSBdbrIm3cQIeacg==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.73.0.tgz",
+      "integrity": "sha512-Eyf1SrP3+yR1DI3OJgOY2Pvrr9dWP9TK37xPaDYycwTtlGlI45erJAVIfH5/m/xosDt6BupJYEFi47bvbTuuyw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-arm64-musl": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.73.0.tgz",
+      "integrity": "sha512-IlT/OJApEDKaMmCooHuncgJZbbCe7T5QIWmTZBEtYscWvzPQuuEinVcid6kwQRVQOUdb7PUCz4jQHnaYXdfJXw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-ppc64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.73.0.tgz",
+      "integrity": "sha512-L+JYcb/vdg5fmcH08V6o0YYLU28cTH1SPNulwJdvK9NK49aXSkYy6oNpKBmddArVOXYqNepriDGiZ04G54kh1Q==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-gnu/-/binding-linux-riscv64-gnu-1.73.0.tgz",
+      "integrity": "sha512-Qtk0g3bKV6OwWjIm7R8kQN1uOZRKQt/MODK2a8QfkwhTpXBD53ozx5XLVWLGDQAVyp2otLW4D2wB98XfAfMPGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-riscv64-musl": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-riscv64-musl/-/binding-linux-riscv64-musl-1.73.0.tgz",
+      "integrity": "sha512-wX0NQKZVxltkAOVmzFcpOaMpdaUvsq1Eqpx9tkAfl71UdkTlSo1R4AdAnGccR1Fm2+TzFgZ22CyyGuZ41RDr/A==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-s390x-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.73.0.tgz",
+      "integrity": "sha512-vPe7UGBMWyiLTtnqS4xxgMQFSFGmtQwhwCxuiw6lXygaO6bVt0D8dFVg8Xv05eaiN3ybC0HXXHUAohFMFvqoCQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-gnu": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.73.0.tgz",
+      "integrity": "sha512-2CwIWr9cemFC/CbRBWZvuk5mffz6ObmfFkfcC/9rTQ7f+icNhYr2kOjf9Rt8lLvugvkdGDOmkoVoFFHh6ClCTw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-linux-x64-musl": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-linux-x64-musl/-/binding-linux-x64-musl-1.73.0.tgz",
+      "integrity": "sha512-nDadfJgg7NBBxG0N560wOe7LLX5QiYp6qBaI7viuk5EUORFBktU/NfV0MbTqU3gTqQDCh4VyxKdo5VADxk9w8Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-openharmony-arm64": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-openharmony-arm64/-/binding-openharmony-arm64-1.73.0.tgz",
+      "integrity": "sha512-wGjJC+NLH9xP+IKGn9RDW94ojJR/wPbg5WCnQjj/oReaOtCQthr8ws1zICe77JFmo4ouUdeTHHZL/ESGiF6Pmw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-arm64-msvc": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.73.0.tgz",
+      "integrity": "sha512-I7X47GPGljw225YUQ5SbC/rb1Kkdrd0yQf0x+hYxeKS6DpfjMbo9ccQPQ6LNY6BoJQ1sHhgDUGuMn5Vg5gHT6w==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-ia32-msvc": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.73.0.tgz",
+      "integrity": "sha512-5lWj+3h+74Fm1jYOO9qkJA4xkAlZA099DkXppuXsk7UpnpZLttsefrZU469vChGaG6hcSqrkKXQOvMTZtbjeNg==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@oxlint/binding-win32-x64-msvc": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/@oxlint/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.73.0.tgz",
+      "integrity": "sha512-WaNRvh4f6zY9CvUQk2YoA1O90ieWrIklI84+HXFr9Isjz9CSESrdqo/RtIYt4Dll/cAchqGDMehfaZd0vqEFZw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
     "node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/@pkgjs/parseargs/-/parseargs-0.11.0.tgz",
@@ -1238,9 +1562,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1258,9 +1579,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1278,9 +1596,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1298,9 +1613,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1318,9 +1630,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1338,9 +1647,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -4436,9 +4742,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4460,9 +4763,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4484,9 +4784,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -4508,9 +4805,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MPL-2.0",
       "optional": true,
       "os": [
@@ -5287,6 +5581,55 @@
       "license": "ISC",
       "dependencies": {
         "wrappy": "1"
+      }
+    },
+    "node_modules/oxlint": {
+      "version": "1.73.0",
+      "resolved": "https://registry.npmjs.org/oxlint/-/oxlint-1.73.0.tgz",
+      "integrity": "sha512-u91G9TJzU6yqKWNZUYprQB07W7YvntZXaRxQ6CkoytepYhLWUXWsr1M8zUJ34VatNPuUAr3Z8GH+O2A331CluQ==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "oxlint": "bin/oxlint"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      },
+      "optionalDependencies": {
+        "@oxlint/binding-android-arm-eabi": "1.73.0",
+        "@oxlint/binding-android-arm64": "1.73.0",
+        "@oxlint/binding-darwin-arm64": "1.73.0",
+        "@oxlint/binding-darwin-x64": "1.73.0",
+        "@oxlint/binding-freebsd-x64": "1.73.0",
+        "@oxlint/binding-linux-arm-gnueabihf": "1.73.0",
+        "@oxlint/binding-linux-arm-musleabihf": "1.73.0",
+        "@oxlint/binding-linux-arm64-gnu": "1.73.0",
+        "@oxlint/binding-linux-arm64-musl": "1.73.0",
+        "@oxlint/binding-linux-ppc64-gnu": "1.73.0",
+        "@oxlint/binding-linux-riscv64-gnu": "1.73.0",
+        "@oxlint/binding-linux-riscv64-musl": "1.73.0",
+        "@oxlint/binding-linux-s390x-gnu": "1.73.0",
+        "@oxlint/binding-linux-x64-gnu": "1.73.0",
+        "@oxlint/binding-linux-x64-musl": "1.73.0",
+        "@oxlint/binding-openharmony-arm64": "1.73.0",
+        "@oxlint/binding-win32-arm64-msvc": "1.73.0",
+        "@oxlint/binding-win32-ia32-msvc": "1.73.0",
+        "@oxlint/binding-win32-x64-msvc": "1.73.0"
+      },
+      "peerDependencies": {
+        "oxlint-tsgolint": ">=0.24.0",
+        "vite-plus": "*"
+      },
+      "peerDependenciesMeta": {
+        "oxlint-tsgolint": {
+          "optional": true
+        },
+        "vite-plus": {
+          "optional": true
+        }
       }
     },
     "node_modules/p-limit": {

--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "test:e2e:ui": "playwright test --ui",
     "typecheck": "tsc --noEmit",
     "typecheck:server": "tsc -p tsconfig.server.json --noEmit",
-    "lint": "echo 'Add eslint config to enable linting'"
+    "lint": "oxlint"
   },
   "dependencies": {
     "@hookform/resolvers": "^5.2.2",
@@ -69,6 +69,7 @@
     "concurrently": "^10.0.0",
     "jsdom": "^29.0.2",
     "mongodb-memory-server": "^11.0.1",
+    "oxlint": "^1.73.0",
     "tsx": "^4.21.0",
     "typescript": "^7.0.0",
     "vite": "^8.0.4",

--- a/shared/lib/extraction.ts
+++ b/shared/lib/extraction.ts
@@ -25,7 +25,7 @@ export function extractContactInfo(text: string): Partial<ExtractedData> {
   let street = '';
   let city = '';
   let postalCode = '';
-  let country = 'Germany'; // Default to Germany
+  const country = 'Germany'; // Default to Germany
   let contactName = '';
   let email = '';
   let phone = '';
@@ -38,7 +38,7 @@ export function extractContactInfo(text: string): Partial<ExtractedData> {
     }
 
     // Phone pattern (starts with + or digit, contains spaces/dashes)
-    if (/^\+?\d[\d\s\-\/()]{6,}/.test(line)) {
+    if (/^\+?\d[\d\s\-/()]{6,}/.test(line)) {
       phone = line;
       continue;
     }

--- a/src/client/App.tsx
+++ b/src/client/App.tsx
@@ -2,8 +2,6 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { ProtectedRoute } from './components/ProtectedRoute';
 import { LoginPage } from './pages/LoginPage';
 import { DashboardPage } from './pages/DashboardPage';
-import { ConfigDetailPage } from './pages/ConfigDetailPage';
-import { ConfigNewPage } from './pages/ConfigNewPage';
 import { SettingsPage } from './pages/SettingsPage';
 import { AuthCallbackPage } from './pages/AuthCallbackPage';
 import { AssociationsPage } from './pages/AssociationsPage';

--- a/src/client/components/Offer/types.ts
+++ b/src/client/components/Offer/types.ts
@@ -1,5 +1,3 @@
-import { Types } from 'mongoose';
-
 export type WizardStep = 'step1' | 'step2';
 export type PathChoice = 'paste' | 'existing';
 

--- a/src/client/components/OfferCard.tsx
+++ b/src/client/components/OfferCard.tsx
@@ -144,7 +144,11 @@ export function OfferCard({
                 className="btn btn-ghost btn-sm"
                 onClick={(e) => {
                   e.stopPropagation();
-                  onView ? onView() : navigate(`/offers/${id}`);
+                  if (onView) {
+                    onView();
+                  } else {
+                    navigate(`/offers/${id}`);
+                  }
                 }}
               >
                 View

--- a/src/client/components/OfferTable.tsx
+++ b/src/client/components/OfferTable.tsx
@@ -55,7 +55,7 @@ export function OfferTable({
     ? offers.filter((o) => o.status === filterStatus)
     : offers;
 
-  const sortedOffers = [...filteredOffers].sort((a, b) => {
+  const sortedOffers = [...filteredOffers].toSorted((a, b) => {
     if (sortBy === 'createdAt') {
       return new Date(b.createdAt).getTime() - new Date(a.createdAt).getTime();
     }

--- a/src/client/lib/dashboardUtils.ts
+++ b/src/client/lib/dashboardUtils.ts
@@ -1,5 +1,3 @@
-import type { FinancialConfig, CalculationResult } from '../../../shared/types';
-
 /**
  * Offer shape as returned by `finance.offers.list`. The list endpoint attaches a
  * per-offer `totalPrice` and a per-league `leaguePrices` breakdown, both derived
@@ -33,7 +31,7 @@ const REVENUE_STATUSES = new Set(['sent', 'accepted', 'sending']);
  */
 export function selectCurrentSeason<T extends { name: string }>(seasons: T[]): T | null {
   if (!seasons.length) return null;
-  return [...seasons].sort((a, b) => Number(b.name) - Number(a.name))[0];
+  return [...seasons].toSorted((a, b) => Number(b.name) - Number(a.name))[0];
 }
 
 /** Gross revenue = sum of `totalPrice` for revenue-bearing offers in the season. */
@@ -77,7 +75,7 @@ export function buildActiveContracts(
       });
     });
 
-  return rows.sort((a, b) => a.leagueName.localeCompare(b.leagueName));
+  return rows.toSorted((a, b) => a.leagueName.localeCompare(b.leagueName));
 }
 
 /** Leagues in the season that have no offer at all. */
@@ -96,7 +94,7 @@ export function buildMissingContracts(
   return leagues
     .filter(l => !contracted.has(l.id))
     .map(l => ({ id: l.id, name: l.name }))
-    .sort((a, b) => a.name.localeCompare(b.name));
+    .toSorted((a, b) => a.name.localeCompare(b.name));
 }
 
 export type DashboardRow =
@@ -147,7 +145,7 @@ export function groupDashboardData(
     group.rows.push({ type: 'PENDING', ...item });
   }
 
-  const sortedGroups = Array.from(groups.values()).sort((a, b) => b.seasonId - a.seasonId);
+  const sortedGroups = Array.from(groups.values()).toSorted((a, b) => b.seasonId - a.seasonId);
 
   for (const group of sortedGroups) {
     group.rows.sort((a, b) => {

--- a/src/client/pages/AssociationsPage.tsx
+++ b/src/client/pages/AssociationsPage.tsx
@@ -166,7 +166,7 @@ export function AssociationsPage() {
                     assocId = assoc._id;
                   }
 
-                  let contactId = data.createdEntities.contactId;
+                  const contactId = data.createdEntities.contactId;
                   if (!contactId) {
                     await createContact.mutateAsync({
                       name: data.contact.name,

--- a/src/client/pages/OfferDetailPage.tsx
+++ b/src/client/pages/OfferDetailPage.tsx
@@ -54,10 +54,6 @@ export function OfferDetailPage() {
   );
   const { data: seasons = [] } = trpc.finance.seasons.list.useQuery();
 
-  const markSent = trpc.finance.offers.markSent.useMutation({
-    onSuccess: () => refetch(),
-  });
-
   const markAccepted = trpc.finance.offers.markAccepted.useMutation({
     onSuccess: () => refetch(),
   });

--- a/src/server/app.ts
+++ b/src/server/app.ts
@@ -163,7 +163,7 @@ export function createApp() {
 
         // Return token in response (for API tests)
         res.json({ token, userId: testUser._id });
-      } catch (error) {
+      } catch {
         res.status(500).json({ error: 'Failed to create test token' });
       }
     });

--- a/src/server/db/migrations/003-update-offer-unique-index.js
+++ b/src/server/db/migrations/003-update-offer-unique-index.js
@@ -11,7 +11,7 @@ module.exports = {
     // Drop the old unique index
     try {
       await collection.dropIndex('associationId_1_seasonId_1_status_1');
-    } catch (err) {
+    } catch {
       // Index may not exist, ignore
     }
 
@@ -28,7 +28,7 @@ module.exports = {
     // Drop the new index
     try {
       await collection.dropIndex('associationId_1_seasonId_1_status_1');
-    } catch (err) {
+    } catch {
       // Index may not exist, ignore
     }
 

--- a/src/server/globals.d.ts
+++ b/src/server/globals.d.ts
@@ -12,4 +12,4 @@ declare global {
   function afterAll(fn: () => void | Promise<void>): void;
 }
 
-export {};
+

--- a/src/server/jobs/queue.ts
+++ b/src/server/jobs/queue.ts
@@ -7,7 +7,7 @@ class MockQueue {
   private jobId = 0;
   private eventHandlers: { [key: string]: Function[] } = {};
 
-  async add(data: any, options?: any) {
+  async add(data: any, _options?: any) {
     const id = String(++this.jobId);
     this.jobs.set(id, {
       id,
@@ -24,7 +24,7 @@ class MockQueue {
     return this.jobs.get(id) || null;
   }
 
-  process(handler: Function) {
+  process(_handler: Function) {
     // Mock processor - jobs complete immediately
   }
 

--- a/src/server/lib/offerCalculator.ts
+++ b/src/server/lib/offerCalculator.ts
@@ -1,4 +1,4 @@
-import { calculateCosts, CalculationDiscount } from './financeCalculator';
+import { calculateCosts } from './financeCalculator';
 
 export interface LeagueConfigForOffer {
   leagueId: number;

--- a/src/server/routers/finance/dashboard.ts
+++ b/src/server/routers/finance/dashboard.ts
@@ -1,5 +1,5 @@
 import { router, protectedProcedure } from '../../trpc';
-import { FinancialConfig, IFinancialConfig } from '../../models/FinancialConfig';
+import { FinancialConfig } from '../../models/FinancialConfig';
 import { Discount } from '../../models/Discount';
 import { getOrCreateSettings } from '../../models/FinancialSettings';
 import { getMysqlPool } from '../../db/mysql';

--- a/src/server/routers/finance/offers.ts
+++ b/src/server/routers/finance/offers.ts
@@ -2,7 +2,7 @@ import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { Types } from 'mongoose';
 import { router, protectedProcedure, adminProcedure } from '../../trpc';
-import { CreateOfferSchema, UpdateOfferSchema } from '../../../../shared/schemas/offer';
+import { UpdateOfferSchema } from '../../../../shared/schemas/offer';
 import { UpdateFinancialConfigSchema } from '../../../../shared/schemas/financialConfig';
 import { Offer } from '../../models/Offer';
 import { FinancialConfig } from '../../models/FinancialConfig';

--- a/src/server/routers/google.ts
+++ b/src/server/routers/google.ts
@@ -1,4 +1,3 @@
-import { z } from 'zod';
 import { TRPCError } from '@trpc/server';
 import { router, adminProcedure } from '../trpc';
 import { DriveService } from '../services/DriveService';

--- a/src/server/services/DriveService.ts
+++ b/src/server/services/DriveService.ts
@@ -43,7 +43,7 @@ export class DriveService {
         webViewLink: response.data.webViewLink || '',
       };
     } catch (err: any) {
-      throw new Error(`Drive upload failed: ${err.message}`);
+      throw new Error(`Drive upload failed: ${err.message}`, { cause: err });
     }
   }
 
@@ -56,7 +56,7 @@ export class DriveService {
 
       return response.data.webViewLink || '';
     } catch (err: any) {
-      throw new Error(`Failed to create shareable link: ${err.message}`);
+      throw new Error(`Failed to create shareable link: ${err.message}`, { cause: err });
     }
   }
 
@@ -70,7 +70,7 @@ export class DriveService {
       return response.data.mimeType === 'application/vnd.google-apps.folder';
     } catch (err: any) {
       if (err.status === 404) return false;
-      throw new Error(`Failed to validate folder: ${err.message}`);
+      throw new Error(`Failed to validate folder: ${err.message}`, { cause: err });
     }
   }
 

--- a/test-offer-creation.ts
+++ b/test-offer-creation.ts
@@ -2,7 +2,6 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest';
 import { Contact } from './src/server/models/Contact';
 import { Association } from './src/server/models/Association';
 import { Season } from './src/server/models/Season';
-import { Offer } from './src/server/models/Offer';
 import { connectMongo, disconnectMongo } from './src/server/db/mongo';
 import { appRouter } from './src/server/routers/index';
 import { createInnerTRPCContext } from './src/server/trpc';

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -7,14 +7,14 @@ let version = 'dev';
 
 try {
   gitHash = execSync('git rev-parse --short HEAD').toString().trim();
-} catch (e) {
+} catch {
   // Fallback for Docker builds or environments without git
   gitHash = (process.env.VITE_GIT_COMMIT_HASH || 'unknown').slice(0, 7);
 }
 
 try {
   version = execSync('git describe --tags --abbrev=0 2>/dev/null').toString().trim();
-} catch (e) {
+} catch {
   version = process.env.VITE_BUILD_VERSION || 'dev';
 }
 


### PR DESCRIPTION
## Summary

Mirrors [dachrisch/energy.consumption#436](https://github.com/dachrisch/energy.consumption/pull/436/changes) by introducing **oxlint** as the linter for this project. Until now `npm run lint` was just a placeholder (`echo 'Add eslint config...'`), so the codebase had never been linted.

### Tooling
- Add `.oxlintrc.json` (`correctness: error`, `suspicious: warn`, `pedantic: off`) adapted to this repo's layout (client/server/shared, `dist/`, e2e, playwright output).
- Add `oxlint@^1.73.0` dev dependency and point the `lint` script at `oxlint`.
- Rename the CI step **"Run eslint" → "Run oxlint"** in `part_node_build.yaml` (the `checkout@v7` / `setup-node@v6` bumps from the reference PR were already present here).

### Notable decision — `eqeqeq`
All loose-equality hits were intentional `== null` / `!= null` guards (which match **both** `null` and `undefined`). Rewriting them to `=== null` would silently drop the `undefined` case, so `eqeqeq` is configured as `["error", "always", { "null": "ignore" }]` — still catching every other loose comparison.

### Cleanup of the 25 pre-existing violations
- Removed dead imports/vars: unused `ConfigDetailPage`/`ConfigNewPage` routes in `App.tsx`, unused type imports in `dashboardUtils.ts`, unused router/schema imports, and an **unused `markSent` mutation** in `OfferDetailPage.tsx` (never wired to a control — flagging here in case it was meant to be).
- Prefixed unused params / used optional catch binding (`catch {}`).
- Converted a ternary-as-statement to `if/else` in `OfferCard.tsx`.
- Applied oxlint's safe auto-fixes (`prefer-const`, `no-useless-escape`, error `cause` chaining, `.sort()` → `.toSorted()` on the client). Kept `.sort()` in `run-migrations.ts` because the **server** tsconfig `lib` target predates es2023.

### Out of scope
`tsconfig.json` has pre-existing TS7 `baseUrl` errors that surface under `npm run typecheck` (client) — untouched here; that script is not part of CI.

## Verification
- ✅ `npm run lint` — 0 errors (warnings remain, non-blocking)
- ✅ `npm run build` — client (vite) + server (`tsc -p tsconfig.server.json`)
- ✅ `npm run test` — 250 passing (40 files)

🤖 Generated with [Claude Code](https://claude.com/claude-code)